### PR TITLE
wiz cli CHEF-32378

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -1,0 +1,136 @@
+# build-docker-image.yml
+# Reusable workflow to build a Docker image and upload it as an artifact.
+# Supports three build strategies:
+#   1. build-docker.sh script (e.g., dsm-erchef)
+#   2. Makefile with compose-build target
+#   3. Standard docker build (fallback)
+#
+# The built image is saved as a tar and uploaded as a GitHub Actions artifact
+# for downstream jobs (e.g., Wiz CLI scan, Grype scan) to consume.
+
+name: Build Docker image
+
+on:
+  workflow_call:
+    inputs:
+      skip-aws:
+        description: 'Skip AWS ECR login (for repos that do not need ECR base images)'
+        required: false
+        type: boolean
+        default: false
+    outputs:
+      image-names:
+        description: 'Space-separated list of built Docker image names (repository:tag)'
+        value: ${{ jobs.build.outputs.image-names }}
+
+jobs:
+  build:
+    name: Build and upload Docker image
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    outputs:
+      image-names: ${{ steps.build-image.outputs.IMAGES }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Configure git for private repos
+        run: git config --global url."https://${{ secrets.GH_TOKEN }}@github.com/".insteadOf "https://github.com/"
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        if: ${{ !inputs.skip-aws }}
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-session-token: ${{ secrets.AWS_SESSION_TOKEN }}
+          aws-region: us-east-2
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        if: ${{ !inputs.skip-aws }}
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build Docker image
+        id: build-image
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: |
+          if [ ! -f "Dockerfile" ]; then
+            echo "❌ No Dockerfile found - cannot build"
+            exit 1
+          fi
+
+          echo "Building Docker image..."
+          REPO_NAME=$(basename $(pwd))
+
+          # Strategy 1: Check for build-docker.sh script (e.g., dsm-erchef)
+          if [ -f "build-docker.sh" ]; then
+            echo "Found build-docker.sh script - using it to build images"
+            chmod +x build-docker.sh
+            GITHUB_TOKEN="${{ secrets.GH_TOKEN }}" ./build-docker.sh
+
+            # Detect all images built (typically repo name or repo-name-init)
+            IMAGES=$(docker images --format "{{.Repository}}:{{.Tag}}" | grep -E "^${REPO_NAME}" | grep -v "^<none>")
+
+            if [ -z "$IMAGES" ]; then
+              echo "⚠️ No images found with prefix ${REPO_NAME} after build-docker.sh"
+              echo "Checking for any recently built images..."
+              IMAGES=$(docker images --format "{{.CreatedAt}}\t{{.Repository}}:{{.Tag}}" | sort -r | head -5 | cut -f2 | grep -v "^<none>")
+            fi
+          # Strategy 2: Check for Makefile with compose-build target (e.g., chef-platform-user-accounts-service)
+          elif [ -f "Makefile" ] && grep -q "^compose-build:" Makefile; then
+            echo "Using Makefile compose-build target with GITHUB_TOKEN"
+            export GITHUB_TOKEN="${{ secrets.GH_TOKEN }}"
+            make compose-build
+
+            echo "Detecting built images..."
+            # Get all image names from compose, then keep only ones that exist locally (i.e., were actually built)
+            IMAGES=""
+            for img in $(docker compose config --images 2>/dev/null | sort -u); do
+              TAG_IMG=$(echo "$img" | grep -q ':' && echo "$img" || echo "${img}:latest")
+              if docker image inspect "$TAG_IMG" &>/dev/null; then
+                IMAGES="${IMAGES}${TAG_IMG} "
+              fi
+            done
+            IMAGES=$(echo "$IMAGES" | xargs)
+
+            if [ -z "$IMAGES" ]; then
+              echo "⚠️ Could not detect built images from compose config, falling back to repo name match"
+              IMAGES=$(docker images --format "{{.Repository}}:{{.Tag}}" | grep "^${REPO_NAME}" | grep -v "^<none>")
+            fi
+          # Strategy 3: Fallback to standard docker build
+          else
+            echo "Using standard docker build with GITHUB_TOKEN build arg"
+            docker build --build-arg GITHUB_TOKEN="${{ secrets.GH_TOKEN }}" -t "${REPO_NAME}:latest" .
+            IMAGES="${REPO_NAME}:latest"
+          fi
+
+          if [ -z "$IMAGES" ]; then
+            echo "❌ No Docker images found after build"
+            exit 1
+          fi
+
+          echo "Found images:"
+          echo "$IMAGES"
+
+          # Output as space-separated list for downstream jobs
+          echo "IMAGES=$(echo $IMAGES | tr '\n' ' ')" >> "$GITHUB_OUTPUT"
+
+      - name: Save Docker images to tar
+        run: |
+          IMAGES="${{ steps.build-image.outputs.IMAGES }}"
+          echo "Saving images to /tmp/docker-image.tar: $IMAGES"
+          docker save $IMAGES -o /tmp/docker-image.tar
+          ls -lh /tmp/docker-image.tar
+
+      - name: Upload Docker image artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: docker-image-for-scans
+          path: /tmp/docker-image.tar
+          retention-days: 1

--- a/.github/workflows/ci-main-pull-request.yml
+++ b/.github/workflows/ci-main-pull-request.yml
@@ -156,8 +156,8 @@ on:
         required: false
         type: boolean
         default: false
-      grype-image-skip-aws:
-        description: 'Skip Grype image scan on AWS ECR images to avoid rate limits (assumes these images are scanned with Amazon ECR scan or Trivy)'
+      image-skip-aws:
+        description: 'Skip AWS ECR login for Docker image scans (for repos that do not need ECR base images)'
         required: false
         type: boolean
         default: false
@@ -1017,22 +1017,36 @@ jobs:
     name: 'Grype Docker image scan'
     if: ${{ inputs.perform-grype-image-scan }}
     uses: chef/common-github-actions/.github/workflows/grype.yml@main
-    needs: checkout
+    needs: [checkout, build-docker-image]
     secrets: inherit
     with:
       fail-grype-on-high: ${{ inputs.grype-image-fail-on-high }}
       fail-grype-on-critical: ${{ inputs.grype-image-fail-on-critical }}
-      grype-image-skip-aws: ${{ inputs.grype-image-skip-aws }}
+      grype-image-skip-aws: ${{ inputs.image-skip-aws }}
+      prebuilt-image-artifact: docker-image-for-scans
+      prebuilt-image-names: ${{ needs.build-docker-image.outputs.image-names }}
+
+  build-docker-image:
+    name: 'Build Docker image for security scans'
+    if: ${{ inputs.perform-grype-image-scan == true || inputs.perform-wiz-scan == true }}
+    uses: chef/common-github-actions/.github/workflows/build-docker-image.yml@main
+    needs: checkout
+    secrets: inherit
+    with:
+      skip-aws: ${{ inputs.image-skip-aws }}
 
   run-wiz-scan:
     name: 'Wiz CLI security scan'
     if: ${{ inputs.perform-wiz-scan == true }}
-    uses: chef/common-github-actions/.github/workflows/wiz.yml@grype-wiz
-    needs: checkout
+    uses: chef/common-github-actions/.github/workflows/wiz.yml@main
+    needs: [checkout, build-docker-image]
     with:
       fail-build: ${{ inputs.wiz-fail-build }}
       fail-on-critical: ${{ inputs.wiz-fail-on-critical }}
       fail-on-high: ${{ inputs.wiz-fail-on-high }}
+      wiz-image-skip-aws: ${{ inputs.image-skip-aws }}
+      prebuilt-image-artifact: docker-image-for-scans
+      prebuilt-image-names: ${{ needs.build-docker-image.outputs.image-names }}
     secrets: inherit
 
   run-grype-hab-package-scan:
@@ -1176,14 +1190,6 @@ jobs:
     #         VER=$(cat VERSION)
     #         echo "VERSION=$VER" >> $GITHUB_ENV
     #   then ${{ env.VERSION }}
-  
-  run-wiz-scan:
-    name: 'Wiz CLI security scan'
-    if: ${{ inputs.perform-wiz-scan == true }}
-    uses: chef/common-github-actions/.github/workflows/wiz.yml@main
-    with:
-      fail-build: ${{ inputs.wiz-fail-build }}
-    secrets: inherit
 
   set-application-version:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-main-pull-request.yml
+++ b/.github/workflows/ci-main-pull-request.yml
@@ -1176,6 +1176,14 @@ jobs:
     #         VER=$(cat VERSION)
     #         echo "VERSION=$VER" >> $GITHUB_ENV
     #   then ${{ env.VERSION }}
+  
+  run-wiz-scan:
+    name: 'Wiz CLI security scan'
+    if: ${{ inputs.perform-wiz-scan == true }}
+    uses: chef/common-github-actions/.github/workflows/wiz.yml@main
+    with:
+      fail-build: ${{ inputs.wiz-fail-build }}
+    secrets: inherit
 
   set-application-version:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-main-pull-request.yml
+++ b/.github/workflows/ci-main-pull-request.yml
@@ -541,6 +541,26 @@ on:
       #   required: false
       #   default: 'https://polaris.blackduck.com'
       #   type: string
+      perform-wiz-scan:
+        description: 'Perform Wiz CLI security scan on Docker image'
+        required: false
+        type: boolean
+        default: false
+      wiz-fail-build:
+        description: 'Fail the build on Wiz policy violations'
+        required: false
+        type: boolean
+        default: true
+      wiz-fail-on-critical:
+        description: 'Fail the pipeline if Wiz finds CRITICAL vulnerabilities'
+        required: false
+        type: boolean
+        default: false
+      wiz-fail-on-high:
+        description: 'Fail the pipeline if Wiz finds HIGH vulnerabilities'
+        required: false
+        type: boolean
+        default: false
         
 env:
   PRIMARY_APPLICATION: ${{ inputs.application }} # was 'default'   # Custom repo property [primaryApplication]: chef360, automate, infra-server, habitat, supermarket, licensing, downloads, chef-client, inspec, chef-workstation (or derivatives like habitat-builder)
@@ -1004,6 +1024,17 @@ jobs:
       fail-grype-on-critical: ${{ inputs.grype-image-fail-on-critical }}
       grype-image-skip-aws: ${{ inputs.grype-image-skip-aws }}
 
+  run-wiz-scan:
+    name: 'Wiz CLI security scan'
+    if: ${{ inputs.perform-wiz-scan == true }}
+    uses: chef/common-github-actions/.github/workflows/wiz.yml@grype-wiz
+    needs: checkout
+    with:
+      fail-build: ${{ inputs.wiz-fail-build }}
+      fail-on-critical: ${{ inputs.wiz-fail-on-critical }}
+      fail-on-high: ${{ inputs.wiz-fail-on-high }}
+    secrets: inherit
+
   run-grype-hab-package-scan:
     name: 'Grype scan Habitat packages from bldr.habitat.sh'
     if: ${{ inputs.perform-grype-hab-scan == true }}
@@ -1145,7 +1176,7 @@ jobs:
     #         VER=$(cat VERSION)
     #         echo "VERSION=$VER" >> $GITHUB_ENV
     #   then ${{ env.VERSION }}
-  
+
   set-application-version:
     runs-on: ubuntu-latest
     name: 'Detect SBOM version for application'

--- a/.github/workflows/grype.yml
+++ b/.github/workflows/grype.yml
@@ -98,28 +98,15 @@ jobs:
           elif [ -f "Makefile" ] && grep -q "^compose-build:" Makefile; then
             echo "Using Makefile compose-build target with GITHUB_TOKEN"
             export GITHUB_TOKEN="${{ secrets.GH_TOKEN }}"
-            
-            # Record image IDs before build to detect newly built images
-            BEFORE_IDS=$(docker images -q --no-trunc | sort)
-            
             make compose-build
             
             echo "Detecting built images..."
-            # Find newly created images by comparing before/after image IDs
-            AFTER_IDS=$(docker images -q --no-trunc | sort)
-            NEW_IDS=$(comm -13 <(echo "$BEFORE_IDS") <(echo "$AFTER_IDS"))
+            docker compose images
             
-            if [ -n "$NEW_IDS" ]; then
-              IMAGES=""
-              for id in $NEW_IDS; do
-                img=$(docker images --format "{{.Repository}}:{{.Tag}}" --filter "id=${id}" | grep -v "<none>" | head -1)
-                [ -n "$img" ] && IMAGES="${IMAGES}${img}"$'\n'
-              done
-              IMAGES=$(echo "$IMAGES" | grep -v '^$' | sort -u)
-            fi
-
+            IMAGES=$(docker images --format "{{.Repository}}:{{.Tag}}" | grep "^${REPO_NAME}" | grep -v "^<none>")
+            
             if [ -z "$IMAGES" ]; then
-              echo "No new images detected, scanning all recent images"
+              echo "No images found with prefix ${REPO_NAME}, scanning all recent images"
               IMAGES=$(docker images --format "{{.Repository}}:{{.Tag}}" | grep -v "^<none>" | head -5)
             fi
           # Strategy 3: Fallback to standard docker build

--- a/.github/workflows/grype.yml
+++ b/.github/workflows/grype.yml
@@ -22,6 +22,16 @@ on:
         required: false
         type: boolean
         default: false
+      prebuilt-image-artifact:
+        description: 'Name of uploaded artifact containing a Docker image tar (skip Docker build if provided)'
+        required: false
+        type: string
+        default: ''
+      prebuilt-image-names:
+        description: 'Space-separated list of Docker image:tag names inside the prebuilt artifact tar'
+        required: false
+        type: string
+        default: ''
 
 jobs:
   grype-scan:
@@ -65,13 +75,29 @@ jobs:
         if: ${{ !inputs.grype-image-skip-aws }}
         uses: aws-actions/amazon-ecr-login@v2
 
-      - name: Scan with Grype
-        id: grype-scan
+      - name: Download prebuilt Docker image
+        if: ${{ inputs.prebuilt-image-artifact != '' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.prebuilt-image-artifact }}
+          path: /tmp
+
+      - name: Load prebuilt Docker image
+        id: load-image
+        if: ${{ inputs.prebuilt-image-artifact != '' }}
+        run: |
+          echo "Loading prebuilt images from artifact..."
+          docker load -i /tmp/docker-image.tar
+          echo "IMAGES=${{ inputs.prebuilt-image-names }}" >> "$GITHUB_OUTPUT"
+          echo "Loaded images: ${{ inputs.prebuilt-image-names }}"
+          docker images
+
+      - name: Build Docker image
+        id: build-image
+        if: ${{ inputs.prebuilt-image-artifact == '' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
-          SCAN_NAME="${{ github.repository }}"
-          
           if [ ! -f "Dockerfile" ]; then
             echo "❌ No Dockerfile found - this workflow requires a Dockerfile to scan Docker image"
             exit 1
@@ -101,13 +127,19 @@ jobs:
             make compose-build
             
             echo "Detecting built images..."
-            docker compose images
-            
-            IMAGES=$(docker images --format "{{.Repository}}:{{.Tag}}" | grep "^${REPO_NAME}" | grep -v "^<none>")
+            # Get all image names from compose, then keep only ones that exist locally (i.e., were actually built)
+            IMAGES=""
+            for img in $(docker compose config --images 2>/dev/null | sort -u); do
+              TAG_IMG=$(echo "$img" | grep -q ':' && echo "$img" || echo "${img}:latest")
+              if docker image inspect "$TAG_IMG" &>/dev/null; then
+                IMAGES="${IMAGES}${TAG_IMG} "
+              fi
+            done
+            IMAGES=$(echo "$IMAGES" | xargs)
             
             if [ -z "$IMAGES" ]; then
-              echo "No images found with prefix ${REPO_NAME}, scanning all recent images"
-              IMAGES=$(docker images --format "{{.Repository}}:{{.Tag}}" | grep -v "^<none>" | head -5)
+              echo "⚠️ Could not detect built images from compose config, falling back to repo name match"
+              IMAGES=$(docker images --format "{{.Repository}}:{{.Tag}}" | grep "^${REPO_NAME}" | grep -v "^<none>")
             fi
           # Strategy 3: Fallback to standard docker build
           else
@@ -120,6 +152,28 @@ jobs:
             echo "❌ No Docker images found after build"
             exit 1
           fi
+          
+          echo "IMAGES=$(echo $IMAGES | tr '\n' ' ')" >> "$GITHUB_OUTPUT"
+          echo "Found images: $IMAGES"
+
+      - name: Determine scan targets
+        id: scan-target
+        run: |
+          IMAGES="${{ steps.load-image.outputs.IMAGES || steps.build-image.outputs.IMAGES }}"
+          if [ -z "$IMAGES" ]; then
+            echo "❌ No images available to scan"
+            exit 1
+          fi
+          echo "IMAGES=$IMAGES" >> "$GITHUB_OUTPUT"
+          echo "Scan targets: $IMAGES"
+
+      - name: Scan with Grype
+        id: grype-scan
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: |
+          SCAN_NAME="${{ github.repository }}"
+          IMAGES="${{ steps.scan-target.outputs.IMAGES }}"
           
           echo "Found images to scan:"
           echo "$IMAGES"

--- a/.github/workflows/grype.yml
+++ b/.github/workflows/grype.yml
@@ -98,15 +98,28 @@ jobs:
           elif [ -f "Makefile" ] && grep -q "^compose-build:" Makefile; then
             echo "Using Makefile compose-build target with GITHUB_TOKEN"
             export GITHUB_TOKEN="${{ secrets.GH_TOKEN }}"
+            
+            # Record image IDs before build to detect newly built images
+            BEFORE_IDS=$(docker images -q --no-trunc | sort)
+            
             make compose-build
             
             echo "Detecting built images..."
-            docker compose images
+            # Find newly created images by comparing before/after image IDs
+            AFTER_IDS=$(docker images -q --no-trunc | sort)
+            NEW_IDS=$(comm -13 <(echo "$BEFORE_IDS") <(echo "$AFTER_IDS"))
             
-            IMAGES=$(docker images --format "{{.Repository}}:{{.Tag}}" | grep "^${REPO_NAME}" | grep -v "^<none>")
-            
+            if [ -n "$NEW_IDS" ]; then
+              IMAGES=""
+              for id in $NEW_IDS; do
+                img=$(docker images --format "{{.Repository}}:{{.Tag}}" --filter "id=${id}" | grep -v "<none>" | head -1)
+                [ -n "$img" ] && IMAGES="${IMAGES}${img}"$'\n'
+              done
+              IMAGES=$(echo "$IMAGES" | grep -v '^$' | sort -u)
+            fi
+
             if [ -z "$IMAGES" ]; then
-              echo "No images found with prefix ${REPO_NAME}, scanning all recent images"
+              echo "No new images detected, scanning all recent images"
               IMAGES=$(docker images --format "{{.Repository}}:{{.Tag}}" | grep -v "^<none>" | head -5)
             fi
           # Strategy 3: Fallback to standard docker build

--- a/.github/workflows/wiz.yml
+++ b/.github/workflows/wiz.yml
@@ -24,6 +24,21 @@ on:
         required: false
         type: boolean
         default: false
+      wiz-image-skip-aws:
+        description: 'Skip AWS ECR login (for repos that do not need ECR base images)'
+        required: false
+        type: boolean
+        default: false
+      prebuilt-image-artifact:
+        description: 'Name of uploaded artifact containing a Docker image tar (skip Docker build if provided)'
+        required: false
+        type: string
+        default: ''
+      prebuilt-image-names:
+        description: 'Space-separated list of Docker image:tag names inside the prebuilt artifact tar'
+        required: false
+        type: string
+        default: ''
 
 jobs:
   wiz-scan:
@@ -41,22 +56,46 @@ jobs:
       - name: Configure git for private repos
         run: git config --global url."https://${{ secrets.GH_TOKEN }}@github.com/".insteadOf "https://github.com/"
 
-      # - name: Configure AWS credentials
-      #   uses: aws-actions/configure-aws-credentials@v4
-      #   if: ${{ !inputs.wiz-image-skip-aws }}
-      #   with:
-      #     aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      #     aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      #     aws-session-token: ${{ secrets.AWS_SESSION_TOKEN }}
-      #     aws-region: us-east-2
+      - name: Generate Artifact Name
+        run: |
+            TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+            ARTIFACT_NAME=$(echo "wiz-scan-${{ github.event.repository.name }}-${TIMESTAMP}" | sed 's|/|-|g')
+            echo "ARTIFACT_NAME=${ARTIFACT_NAME}" >> $GITHUB_ENV
 
-      # - name: Login to Amazon ECR
-      #   id: login-ecr
-      #   if: ${{ !inputs.wiz-image-skip-aws }}
-      #   uses: aws-actions/amazon-ecr-login@v2
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        if: ${{ !inputs.wiz-image-skip-aws }}
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-session-token: ${{ secrets.AWS_SESSION_TOKEN }}
+          aws-region: us-east-2
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        if: ${{ !inputs.wiz-image-skip-aws }}
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Download prebuilt Docker image
+        if: ${{ inputs.prebuilt-image-artifact != '' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.prebuilt-image-artifact }}
+          path: /tmp
+
+      - name: Load prebuilt Docker image
+        id: load-image
+        if: ${{ inputs.prebuilt-image-artifact != '' }}
+        run: |
+          echo "Loading prebuilt images from artifact..."
+          docker load -i /tmp/docker-image.tar
+          echo "IMAGES=${{ inputs.prebuilt-image-names }}" >> "$GITHUB_OUTPUT"
+          echo "Loaded images: ${{ inputs.prebuilt-image-names }}"
+          docker images
 
       - name: Build Docker image
         id: build-image
+        if: ${{ inputs.prebuilt-image-artifact == '' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
@@ -74,60 +113,61 @@ jobs:
             chmod +x build-docker.sh
             GITHUB_TOKEN="${{ secrets.GH_TOKEN }}" ./build-docker.sh
 
-            IMAGE=$(docker images --format "{{.Repository}}:{{.Tag}}" | grep -E "^${REPO_NAME}" | grep -v "^<none>" | head -1)
+            IMAGES=$(docker images --format "{{.Repository}}:{{.Tag}}" | grep -E "^${REPO_NAME}" | grep -v "^<none>")
 
-            if [ -z "$IMAGE" ]; then
-              echo "⚠️ No image found with prefix ${REPO_NAME} after build-docker.sh"
+            if [ -z "$IMAGES" ]; then
+              echo "⚠️ No images found with prefix ${REPO_NAME} after build-docker.sh"
               echo "Checking for any recently built images..."
-              IMAGE=$(docker images --format "{{.CreatedAt}}\t{{.Repository}}:{{.Tag}}" | sort -r | head -1 | cut -f2)
+              IMAGES=$(docker images --format "{{.CreatedAt}}\t{{.Repository}}:{{.Tag}}" | sort -r | head -5 | cut -f2 | grep -v "^<none>")
             fi
           # Strategy 2: Check for Makefile with compose-build target
           elif [ -f "Makefile" ] && grep -q "^compose-build:" Makefile; then
             echo "Using Makefile compose-build target with GITHUB_TOKEN"
             export GITHUB_TOKEN="${{ secrets.GH_TOKEN }}"
-            
-            # Record image IDs before build to detect newly built images
-            BEFORE_IDS=$(docker images -q --no-trunc | sort)
-            
             make compose-build
 
-            echo "Detecting built image..."
-            # Find newly created images by comparing before/after image IDs
-            AFTER_IDS=$(docker images -q --no-trunc | sort)
-            NEW_IDS=$(comm -13 <(echo "$BEFORE_IDS") <(echo "$AFTER_IDS"))
-            
-            if [ -n "$NEW_IDS" ]; then
-              for id in $NEW_IDS; do
-                # Use docker inspect instead of --filter (compatible with all Docker versions)
-                IMAGE=$(docker inspect --format '{{index .RepoTags 0}}' "$id" 2>/dev/null || true)
-                [ -n "$IMAGE" ] && [ "$IMAGE" != "<none>:<none>" ] && break
-                IMAGE=""
-              done
-            fi
+            echo "Detecting built images..."
+            # Get all image names from compose, then keep only ones that exist locally (i.e., were actually built)
+            IMAGES=""
+            for img in $(docker compose config --images 2>/dev/null | sort -u); do
+              TAG_IMG=$(echo "$img" | grep -q ':' && echo "$img" || echo "${img}:latest")
+              if docker image inspect "$TAG_IMG" &>/dev/null; then
+                IMAGES="${IMAGES}${TAG_IMG} "
+              fi
+            done
+            IMAGES=$(echo "$IMAGES" | xargs)
 
-            if [ -z "$IMAGE" ]; then
-              echo "No new image detected by ID comparison, falling back to repo name match"
-              IMAGE=$(docker images --format "{{.Repository}}:{{.Tag}}" | grep -E "^${REPO_NAME}" | grep -v "<none>" | head -1)
-            fi
-
-            if [ -z "$IMAGE" ]; then
-              echo "⚠️ No image found matching ${REPO_NAME}, using most recent non-runner image"
-              IMAGE=$(docker images --format "{{.Repository}}:{{.Tag}}" | grep -v "^<none>" | grep -v "^ghcr.io/github/" | grep -v "^ghcr.io/dependabot/" | head -1)
+            if [ -z "$IMAGES" ]; then
+              echo "⚠️ Could not detect built images from compose config, falling back to repo name match"
+              IMAGES=$(docker images --format "{{.Repository}}:{{.Tag}}" | grep "^${REPO_NAME}" | grep -v "^<none>")
             fi
           # Strategy 3: Fallback to standard docker build
           else
             echo "Using standard docker build with GITHUB_TOKEN build arg"
             docker build --build-arg GITHUB_TOKEN="${{ secrets.GH_TOKEN }}" -t "${REPO_NAME}:latest" .
-            IMAGE="${REPO_NAME}:latest"
+            IMAGES="${REPO_NAME}:latest"
           fi
 
-          if [ -z "$IMAGE" ]; then
-            echo "❌ No Docker image found after build"
+          if [ -z "$IMAGES" ]; then
+            echo "❌ No Docker images found after build"
             exit 1
           fi
 
-          echo "Image to scan: $IMAGE"
-          echo "IMAGE=$IMAGE" >> "$GITHUB_OUTPUT"
+          echo "Found images to scan:"
+          echo "$IMAGES"
+          echo "IMAGES=$(echo $IMAGES | tr '\n' ' ')" >> "$GITHUB_OUTPUT"
+
+      - name: Set scan target images
+        id: scan-target
+        run: |
+          # Use prebuilt images if available, otherwise use freshly built images
+          IMAGES="${{ steps.load-image.outputs.IMAGES || steps.build-image.outputs.IMAGES }}"
+          if [ -z "$IMAGES" ]; then
+            echo "❌ No Docker images available for scanning"
+            exit 1
+          fi
+          echo "Scan targets: $IMAGES"
+          echo "IMAGES=$IMAGES" >> "$GITHUB_OUTPUT"
 
       - name: Fetch Wiz credentials from AKeyless
         id: fetch-secrets
@@ -150,50 +190,55 @@ jobs:
         run: |
           set -o pipefail
 
-          SCAN_TYPE='container-image'
-          SCAN_TARGET='${{ steps.build-image.outputs.IMAGE }}'
+          IMAGES='${{ steps.scan-target.outputs.IMAGES }}'
+          SCAN_RESULT="passed"
 
-          args=("$SCAN_TYPE")
-          if [ -n "$SCAN_TARGET" ]; then
-            args+=("$SCAN_TARGET")
-          fi
+          # Initialize combined output files
+          > /tmp/wiz-scan.json
+          > /tmp/wiz-scan-results.txt
 
-          # Always output JSON for severity analysis
-          args+=("--json-output-file" "/tmp/wiz-scan.json")
+          for IMAGE_NAME in $IMAGES; do
+            echo ""
+            echo "============================================"
+            echo "Scanning Docker image: $IMAGE_NAME"
+            echo "============================================"
 
-          ./wizcli scan "${args[@]}" 2>&1 | tee /tmp/wiz-scan-results.txt
-          EXIT_CODE=${PIPESTATUS[0]}
+            JSON_FILE="/tmp/wiz-scan-$(echo $IMAGE_NAME | tr '/:' '__').json"
+
+            ./wizcli scan container-image "$IMAGE_NAME" --json-output-file "$JSON_FILE" 2>&1 | tee -a /tmp/wiz-scan-results.txt
+            EXIT_CODE=${PIPESTATUS[0]}
+
+            # Append JSON result to combined file
+            cat "$JSON_FILE" >> /tmp/wiz-scan.json 2>/dev/null || true
+
+            if [ $EXIT_CODE -ne 0 ]; then
+              SCAN_RESULT="failed"
+            fi
+          done
 
           echo ""
           echo "============================================"
-          echo "Wiz CLI Scan Output"
+          echo "Wiz CLI Scan Complete - Result: $SCAN_RESULT"
           echo "============================================"
-          cat /tmp/wiz-scan-results.txt
-          echo "============================================"
-          echo ""
 
-          if [ $EXIT_CODE -eq 0 ]; then
-            echo "scan-result=passed" >> $GITHUB_OUTPUT
-          else
-            echo "scan-result=failed" >> $GITHUB_OUTPUT
-          fi
-          exit $EXIT_CODE
+          echo "scan-result=$SCAN_RESULT" >> $GITHUB_OUTPUT
+          [ "$SCAN_RESULT" = "failed" ] && exit 1 || exit 0
 
       - name: Check Wiz results for severity violations
         id: severity-check
         if: always()
         run: |
-          JSON_FILE="/tmp/wiz-scan.json"
+          # Aggregate vulnerability counts across all per-image JSON files
+          CRITICAL_COUNT=0
+          HIGH_COUNT=0
 
-          if [ ! -f "$JSON_FILE" ]; then
-            echo "⚠️  Wiz JSON output not found, skipping severity check"
-            echo "severity-result=skipped" >> $GITHUB_OUTPUT
-            exit 0
-          fi
-
-          # Count vulnerabilities by severity from Wiz JSON analytics summary
-          CRITICAL_COUNT=$(jq '.result.analytics.vulnerabilities.criticalCount // 0' "$JSON_FILE" 2>/dev/null || echo "0")
-          HIGH_COUNT=$(jq '.result.analytics.vulnerabilities.highCount // 0' "$JSON_FILE" 2>/dev/null || echo "0")
+          for JSON_FILE in /tmp/wiz-scan-*.json; do
+            [ -f "$JSON_FILE" ] || continue
+            C=$(jq '.result.analytics.vulnerabilities.criticalCount // 0' "$JSON_FILE" 2>/dev/null || echo "0")
+            H=$(jq '.result.analytics.vulnerabilities.highCount // 0' "$JSON_FILE" 2>/dev/null || echo "0")
+            CRITICAL_COUNT=$((CRITICAL_COUNT + C))
+            HIGH_COUNT=$((HIGH_COUNT + H))
+          done
 
           echo ""
           echo "============================================"
@@ -222,50 +267,11 @@ jobs:
             echo "severity-result=passed" >> $GITHUB_OUTPUT
           fi
 
-      - name: Write Job Summary
-        if: always()
-        run: |
-          SCAN_RESULT="${{ steps.wiz-scan.outputs.scan-result }}"
-          SEVERITY_RESULT="${{ steps.severity-check.outputs.severity-result }}"
-
-          # Overall result: fail if either policy or severity check failed
-          if [ "$SCAN_RESULT" = "passed" ] && [ "$SEVERITY_RESULT" != "failed" ]; then
-            ICON="✅"
-            OVERALL="passed"
-          else
-            ICON="❌"
-            OVERALL="failed"
-          fi
-
-          {
-            echo "## ${ICON} Wiz CLI Scan Results"
-            echo ""
-            echo "| Field | Value |"
-            echo "|-------|-------|"
-            echo "| **Scan type** | \`container-image\` |"
-            echo "| **Target** | \`${{ steps.build-image.outputs.IMAGE }}\` |"
-            echo "| **Policy result** | **${SCAN_RESULT}** |"
-            echo "| **Severity result** | **${SEVERITY_RESULT}** |"
-            echo "| **Overall** | **${OVERALL}** |"
-            echo ""
-            echo "### Vulnerability Counts"
-            echo ""
-            echo "| Severity | Count | Fail on? |"
-            echo "|----------|-------|----------|"
-            echo "| CRITICAL | ${{ steps.severity-check.outputs.critical-count || '0' }} | ${{ inputs.fail-on-critical }} |"
-            echo "| HIGH | ${{ steps.severity-check.outputs.high-count || '0' }} | ${{ inputs.fail-on-high }} |"
-            echo ""
-            echo "### Scan Output"
-            echo '```'
-            cat /tmp/wiz-scan-results.txt 2>/dev/null || echo "(no output captured)"
-            echo '```'
-          } >> "$GITHUB_STEP_SUMMARY"
-
       - name: Upload Wiz scan results
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: wiz-scan-${{ github.event.repository.name }}
+          name: ${{ env.ARTIFACT_NAME }}
           path: |
-            /tmp/wiz-scan.json
+            /tmp/wiz-scan*.json
             /tmp/wiz-scan-results.txt

--- a/.github/workflows/wiz.yml
+++ b/.github/workflows/wiz.yml
@@ -1,0 +1,127 @@
+# wiz.yml
+# Wiz CLI security scan for Docker image vulnerabilities and policy violations
+# Uses the prgs-community/githubactions-reusableworkflows/actions/wizcli composite action
+# which handles Wiz CLI install, AKeyless auth, scanning, and job summary automatically.
+# https://docs.wiz.io/wiz-docs/docs/wiz-cli-overview
+
+name: Wiz CLI security scan
+
+on:
+  workflow_call:
+    inputs:
+      fail-build:
+        description: 'Fail the build on Wiz policy violations'
+        required: false
+        type: boolean
+        default: true
+      wiz-image-skip-aws:
+        description: 'Skip AWS ECR login (assumes images are scanned elsewhere)'
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  wiz-scan:
+    name: Wiz CLI container image scan
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Configure git for private repos
+        run: git config --global url."https://${{ secrets.GH_TOKEN }}@github.com/".insteadOf "https://github.com/"
+
+      # - name: Configure AWS credentials
+      #   uses: aws-actions/configure-aws-credentials@v4
+      #   if: ${{ !inputs.wiz-image-skip-aws }}
+      #   with:
+      #     aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      #     aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      #     aws-session-token: ${{ secrets.AWS_SESSION_TOKEN }}
+      #     aws-region: us-east-2
+
+      # - name: Login to Amazon ECR
+      #   id: login-ecr
+      #   if: ${{ !inputs.wiz-image-skip-aws }}
+      #   uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build Docker image
+        id: build-image
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: |
+          REPO_NAME=$(basename $(pwd))
+
+          if [ ! -f "Dockerfile" ]; then
+            echo "❌ No Dockerfile found - this workflow requires a Dockerfile to scan Docker image"
+            exit 1
+          fi
+
+          echo "Building Docker image..."
+
+          # Strategy 1: Check for build-docker.sh script (e.g., dsm-erchef)
+          if [ -f "build-docker.sh" ]; then
+            echo "Found build-docker.sh script - using it to build images"
+            chmod +x build-docker.sh
+            GITHUB_TOKEN="${{ secrets.GH_TOKEN }}" ./build-docker.sh
+
+            IMAGE=$(docker images --format "{{.Repository}}:{{.Tag}}" | grep -E "^${REPO_NAME}" | grep -v "^<none>" | head -1)
+
+            if [ -z "$IMAGE" ]; then
+              echo "⚠️ No image found with prefix ${REPO_NAME} after build-docker.sh"
+              echo "Checking for any recently built images..."
+              IMAGE=$(docker images --format "{{.CreatedAt}}\t{{.Repository}}:{{.Tag}}" | sort -r | head -1 | cut -f2)
+            fi
+          # Strategy 2: Check for Makefile with compose-build target
+          elif [ -f "Makefile" ] && grep -q "^compose-build:" Makefile; then
+            echo "Using Makefile compose-build target with GITHUB_TOKEN"
+            export GITHUB_TOKEN="${{ secrets.GH_TOKEN }}"
+            
+            # Record image IDs before build to detect newly built images
+            BEFORE_IDS=$(docker images -q --no-trunc | sort)
+            
+            make compose-build
+
+            echo "Detecting built image..."
+            # Find newly created images by comparing before/after image IDs
+            AFTER_IDS=$(docker images -q --no-trunc | sort)
+            NEW_IDS=$(comm -13 <(echo "$BEFORE_IDS") <(echo "$AFTER_IDS"))
+            
+            if [ -n "$NEW_IDS" ]; then
+              for id in $NEW_IDS; do
+                IMAGE=$(docker images --format "{{.Repository}}:{{.Tag}}" --filter "id=${id}" | grep -v "<none>" | head -1)
+                [ -n "$IMAGE" ] && break
+              done
+            fi
+
+            if [ -z "$IMAGE" ]; then
+              echo "No new image detected, using most recent image"
+              IMAGE=$(docker images --format "{{.Repository}}:{{.Tag}}" | grep -v "^<none>" | head -1)
+            fi
+          # Strategy 3: Fallback to standard docker build
+          else
+            echo "Using standard docker build with GITHUB_TOKEN build arg"
+            docker build --build-arg GITHUB_TOKEN="${{ secrets.GH_TOKEN }}" -t "${REPO_NAME}:latest" .
+            IMAGE="${REPO_NAME}:latest"
+          fi
+
+          if [ -z "$IMAGE" ]; then
+            echo "❌ No Docker image found after build"
+            exit 1
+          fi
+
+          echo "Image to scan: $IMAGE"
+          echo "IMAGE=$IMAGE" >> "$GITHUB_OUTPUT"
+
+      - name: Wiz CLI container image scan
+        id: wiz-scan
+        uses: prgs-community/githubactions-reusableworkflows/actions/wizcli@latest
+        with:
+          scan-type: 'container-image'
+          scan-target: ${{ steps.build-image.outputs.IMAGE }}
+          fail-build: ${{ inputs.fail-build }}

--- a/.github/workflows/wiz.yml
+++ b/.github/workflows/wiz.yml
@@ -14,8 +14,13 @@ on:
         required: false
         type: boolean
         default: true
-      wiz-image-skip-aws:
-        description: 'Skip AWS ECR login (assumes images are scanned elsewhere)'
+      fail-on-critical:
+        description: 'Fail the build if Wiz finds CRITICAL vulnerabilities'
+        required: false
+        type: boolean
+        default: false
+      fail-on-high:
+        description: 'Fail the build if Wiz finds HIGH vulnerabilities'
         required: false
         type: boolean
         default: false
@@ -55,14 +60,13 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
-          REPO_NAME=$(basename $(pwd))
-
           if [ ! -f "Dockerfile" ]; then
-            echo "❌ No Dockerfile found - this workflow requires a Dockerfile to scan Docker image"
+            echo "❌ No Dockerfile found - cannot scan"
             exit 1
           fi
 
           echo "Building Docker image..."
+          REPO_NAME=$(basename $(pwd))
 
           # Strategy 1: Check for build-docker.sh script (e.g., dsm-erchef)
           if [ -f "build-docker.sh" ]; then
@@ -94,14 +98,21 @@ jobs:
             
             if [ -n "$NEW_IDS" ]; then
               for id in $NEW_IDS; do
-                IMAGE=$(docker images --format "{{.Repository}}:{{.Tag}}" --filter "id=${id}" | grep -v "<none>" | head -1)
-                [ -n "$IMAGE" ] && break
+                # Use docker inspect instead of --filter (compatible with all Docker versions)
+                IMAGE=$(docker inspect --format '{{index .RepoTags 0}}' "$id" 2>/dev/null || true)
+                [ -n "$IMAGE" ] && [ "$IMAGE" != "<none>:<none>" ] && break
+                IMAGE=""
               done
             fi
 
             if [ -z "$IMAGE" ]; then
-              echo "No new image detected, using most recent image"
-              IMAGE=$(docker images --format "{{.Repository}}:{{.Tag}}" | grep -v "^<none>" | head -1)
+              echo "No new image detected by ID comparison, falling back to repo name match"
+              IMAGE=$(docker images --format "{{.Repository}}:{{.Tag}}" | grep -E "^${REPO_NAME}" | grep -v "<none>" | head -1)
+            fi
+
+            if [ -z "$IMAGE" ]; then
+              echo "⚠️ No image found matching ${REPO_NAME}, using most recent non-runner image"
+              IMAGE=$(docker images --format "{{.Repository}}:{{.Tag}}" | grep -v "^<none>" | grep -v "^ghcr.io/github/" | grep -v "^ghcr.io/dependabot/" | head -1)
             fi
           # Strategy 3: Fallback to standard docker build
           else
@@ -118,10 +129,143 @@ jobs:
           echo "Image to scan: $IMAGE"
           echo "IMAGE=$IMAGE" >> "$GITHUB_OUTPUT"
 
+      - name: Fetch Wiz credentials from AKeyless
+        id: fetch-secrets
+        uses: LanceMcCarthy/akeyless-action@ca2424bb132118c0b907f38e6dae0475acc0fac4 # v5.2.1
+        with:
+          access-id: "p-5g555fgryzj2om"
+          static-secrets: '{"/ProductSecurity/Tools/WIZ_CLIENT_ID":"WIZ_CLIENT_ID","/ProductSecurity/Tools/WIZ_CLIENT_SECRET":"WIZ_CLIENT_SECRET"}'
+
+      - name: Download Wiz CLI
+        run: |
+          curl -fsSL -o wizcli https://downloads.wiz.io/v1/wizcli/latest/wizcli-linux-amd64
+          chmod +x wizcli
+
       - name: Wiz CLI container image scan
         id: wiz-scan
-        uses: prgs-community/githubactions-reusableworkflows/actions/wizcli@latest
+        continue-on-error: true
+        env:
+          WIZ_CLIENT_ID: ${{ steps.fetch-secrets.outputs.WIZ_CLIENT_ID }}
+          WIZ_CLIENT_SECRET: ${{ steps.fetch-secrets.outputs.WIZ_CLIENT_SECRET }}
+        run: |
+          set -o pipefail
+
+          SCAN_TYPE='container-image'
+          SCAN_TARGET='${{ steps.build-image.outputs.IMAGE }}'
+
+          args=("$SCAN_TYPE")
+          if [ -n "$SCAN_TARGET" ]; then
+            args+=("$SCAN_TARGET")
+          fi
+
+          # Always output JSON for severity analysis
+          args+=("--json-output-file" "/tmp/wiz-scan.json")
+
+          ./wizcli scan "${args[@]}" 2>&1 | tee /tmp/wiz-scan-results.txt
+          EXIT_CODE=${PIPESTATUS[0]}
+
+          echo ""
+          echo "============================================"
+          echo "Wiz CLI Scan Output"
+          echo "============================================"
+          cat /tmp/wiz-scan-results.txt
+          echo "============================================"
+          echo ""
+
+          if [ $EXIT_CODE -eq 0 ]; then
+            echo "scan-result=passed" >> $GITHUB_OUTPUT
+          else
+            echo "scan-result=failed" >> $GITHUB_OUTPUT
+          fi
+          exit $EXIT_CODE
+
+      - name: Check Wiz results for severity violations
+        id: severity-check
+        if: always()
+        run: |
+          JSON_FILE="/tmp/wiz-scan.json"
+
+          if [ ! -f "$JSON_FILE" ]; then
+            echo "⚠️  Wiz JSON output not found, skipping severity check"
+            echo "severity-result=skipped" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # Count vulnerabilities by severity from Wiz JSON analytics summary
+          CRITICAL_COUNT=$(jq '.result.analytics.vulnerabilities.criticalCount // 0' "$JSON_FILE" 2>/dev/null || echo "0")
+          HIGH_COUNT=$(jq '.result.analytics.vulnerabilities.highCount // 0' "$JSON_FILE" 2>/dev/null || echo "0")
+
+          echo ""
+          echo "============================================"
+          echo "Wiz Security Scan - Vulnerability Summary"
+          echo "============================================"
+          echo "CRITICAL vulnerabilities: $CRITICAL_COUNT"
+          echo "HIGH vulnerabilities:     $HIGH_COUNT"
+          echo "============================================"
+
+          # Save counts for job summary
+          echo "critical-count=$CRITICAL_COUNT" >> $GITHUB_OUTPUT
+          echo "high-count=$HIGH_COUNT" >> $GITHUB_OUTPUT
+
+          VIOLATIONS=""
+          [ "${{ inputs.fail-on-critical }}" == "true" ] && [ "$CRITICAL_COUNT" -gt 0 ] && VIOLATIONS="${VIOLATIONS}${CRITICAL_COUNT} CRITICAL, "
+          [ "${{ inputs.fail-on-high }}" == "true" ] && [ "$HIGH_COUNT" -gt 0 ] && VIOLATIONS="${VIOLATIONS}${HIGH_COUNT} HIGH, "
+
+          if [ -n "$VIOLATIONS" ]; then
+            echo ""
+            echo "❌ BUILD FAILED: Found ${VIOLATIONS%, } vulnerabilities"
+            echo "severity-result=failed" >> $GITHUB_OUTPUT
+            exit 1
+          else
+            echo ""
+            echo "✅ No severity-violating vulnerabilities found"
+            echo "severity-result=passed" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Write Job Summary
+        if: always()
+        run: |
+          SCAN_RESULT="${{ steps.wiz-scan.outputs.scan-result }}"
+          SEVERITY_RESULT="${{ steps.severity-check.outputs.severity-result }}"
+
+          # Overall result: fail if either policy or severity check failed
+          if [ "$SCAN_RESULT" = "passed" ] && [ "$SEVERITY_RESULT" != "failed" ]; then
+            ICON="✅"
+            OVERALL="passed"
+          else
+            ICON="❌"
+            OVERALL="failed"
+          fi
+
+          {
+            echo "## ${ICON} Wiz CLI Scan Results"
+            echo ""
+            echo "| Field | Value |"
+            echo "|-------|-------|"
+            echo "| **Scan type** | \`container-image\` |"
+            echo "| **Target** | \`${{ steps.build-image.outputs.IMAGE }}\` |"
+            echo "| **Policy result** | **${SCAN_RESULT}** |"
+            echo "| **Severity result** | **${SEVERITY_RESULT}** |"
+            echo "| **Overall** | **${OVERALL}** |"
+            echo ""
+            echo "### Vulnerability Counts"
+            echo ""
+            echo "| Severity | Count | Fail on? |"
+            echo "|----------|-------|----------|"
+            echo "| CRITICAL | ${{ steps.severity-check.outputs.critical-count || '0' }} | ${{ inputs.fail-on-critical }} |"
+            echo "| HIGH | ${{ steps.severity-check.outputs.high-count || '0' }} | ${{ inputs.fail-on-high }} |"
+            echo ""
+            echo "### Scan Output"
+            echo '```'
+            cat /tmp/wiz-scan-results.txt 2>/dev/null || echo "(no output captured)"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload Wiz scan results
+        if: always()
+        uses: actions/upload-artifact@v4
         with:
-          scan-type: 'container-image'
-          scan-target: ${{ steps.build-image.outputs.IMAGE }}
-          fail-build: ${{ inputs.fail-build }}
+          name: wiz-scan-${{ github.event.repository.name }}
+          path: |
+            /tmp/wiz-scan.json
+            /tmp/wiz-scan-results.txt


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This pull request introduces a reusable workflow for building Docker images and integrates it into the main CI pipeline, enabling downstream security scans (Grype and Wiz) to consume a prebuilt Docker image artifact. It also adds a new Wiz CLI security scan workflow and updates the Grype workflow to optionally use prebuilt images, streamlining the image build and scan process for improved efficiency and consistency.

**Key changes include:**

### Docker Image Build and Artifact Handling

* Added `.github/workflows/build-docker-image.yml`, a reusable workflow that builds Docker images using one of three strategies (custom script, Makefile target, or standard Docker build), saves the image(s) as a tarball, and uploads it as an artifact for downstream jobs.
* Updated `.github/workflows/ci-main-pull-request.yml` to use the new `build-docker-image` workflow when Grype or Wiz scans are enabled, and to pass the resulting artifact and image names to downstream scan jobs.

### Security Scans Integration

* Added `.github/workflows/wiz.yml`, a reusable workflow for running Wiz CLI container image scans. It supports scanning prebuilt Docker images, failing the build on policy or severity violations, and uploading scan results as artifacts.
* Enhanced `.github/workflows/grype.yml` to accept prebuilt Docker image artifacts and image names as inputs, allowing it to skip the build step if provided. The workflow now supports loading and scanning prebuilt images, improving scan performance and reliability. [[1]](diffhunk://#diff-74d10460c851667bc932322cb8c2cbf4321ba9f2c5c8a3d180724396fc395a27R25-R34) [[2]](diffhunk://#diff-74d10460c851667bc932322cb8c2cbf4321ba9f2c5c8a3d180724396fc395a27L68-L74) [[3]](diffhunk://#diff-74d10460c851667bc932322cb8c2cbf4321ba9f2c5c8a3d180724396fc395a27L104-R142) [[4]](diffhunk://#diff-74d10460c851667bc932322cb8c2cbf4321ba9f2c5c8a3d180724396fc395a27R156-R177)
* Updated `.github/workflows/ci-main-pull-request.yml` to add new inputs for enabling/disabling Wiz scans and controlling failure behavior based on Wiz scan results.

These changes make the CI pipeline more modular and efficient by decoupling image building from scanning, and by supporting both Grype and Wiz security scans using a common prebuilt Docker image artifact.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
https://progresssoftware.atlassian.net/browse/CHEF-32378

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
