### PR TITLE
fix: preserve HAB_AUTH_TOKEN through sudo and fix Windows hab PATH

### DIFF
--- a/.github/workflows/grype-hab-package-scan.yml
+++ b/.github/workflows/grype-hab-package-scan.yml
@@ -152,7 +152,7 @@ jobs:
             hartifacts=$(ls results/*.hart)
             if [ -f "$hartifacts" ]; then
                 echo "Built package artifact: $hartifacts"
-                sudo hab pkg install $hartifacts
+                sudo -E hab pkg install $hartifacts
             else
                 echo "Error: No .hart file found in results/"
                 exit 1
@@ -189,7 +189,7 @@ jobs:
                 PACKAGE="${PACKAGE}/${{ inputs.hab_release }}"
             fi
             
-            INSTALL_CMD="sudo hab pkg install ${PACKAGE}"
+            INSTALL_CMD="sudo -E hab pkg install ${PACKAGE}"
             
             if [ -n "${{ inputs.hab_channel }}" ]; then
                 INSTALL_CMD="${INSTALL_CMD} --channel ${{ inputs.hab_channel }}"
@@ -298,6 +298,7 @@ jobs:
             echo "HAB_LICENSE=accept-no-persist" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
             New-Item -ItemType Directory -Force -Path "C:\hab\accepted-licenses"
             New-Item -ItemType File -Force -Path "C:\hab\accepted-licenses\habitat"
+            echo "C:\ProgramData\Habitat" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Checkout code
         if: ${{ inputs.build_package == true }}
@@ -582,7 +583,7 @@ jobs:
                 PACKAGE="${PACKAGE}/${{ inputs.hab_release }}"
             fi
             
-            INSTALL_CMD="sudo hab pkg install ${PACKAGE}"
+            INSTALL_CMD="sudo -E hab pkg install ${PACKAGE}"
             
             if [ -n "${{ inputs.hab_channel }}" ]; then
                 INSTALL_CMD="${INSTALL_CMD} --channel ${{ inputs.hab_channel }}"


### PR DESCRIPTION
## Problem

### Linux/macOS
`sudo hab pkg install` was dropping the `HAB_AUTH_TOKEN` environment variable because `sudo` does not preserve env vars by default. The token was correctly set via `export`, but the hab process running under sudo never received it, resulting in **401 Unauthorized** from Builder.

### Windows
The hab binary is installed to `C:\ProgramData\Habitat` but that directory was never added to `GITHUB_PATH` in the *Configure Habitat* step, causing subsequent steps to fail with `hab is not recognized`.

## Fix

- **Linux/macOS:** Changed all three `sudo hab pkg install` invocations to `sudo -E hab pkg install` so the environment (including `HAB_AUTH_TOKEN`) is preserved across the sudo boundary.
- **Windows:** Added `C:\ProgramData\Habitat` to `GITHUB_PATH` in the *Configure Habitat (Windows)* step so the `hab` binary is available in subsequent steps.

## Files Changed

- `.github/workflows/grype-hab-package-scan.yml`