### PR TITLE
Fix typo in #45

### DIFF
--- a/.github/workflows/ci-main-pull-request.yml
+++ b/.github/workflows/ci-main-pull-request.yml
@@ -1300,7 +1300,7 @@ jobs:
       
   BlackDuck-Polaris-SAST:
     name: 'BlackDuck Polaris SAST scan'
-    if: ${{ inputs.perform-blackduck-polaris && github.event_name == 'push' }}}
+    if: ${{ inputs.perform-blackduck-polaris && github.event_name == 'push' }}
     uses: chef/common-github-actions/.github/workflows/polaris-sast.yml@main
     needs: checkout
     secrets: inherit


### PR DESCRIPTION
Triple curly brace is causing it to ALWAYS be positive. Typo.

Signed-off-by: Phil Dibowitz <phil@ipom.com>
