### PR TITLE
Add HAB_AUTH_TOKEN support to automate-container-scan action

### DIFF
--- a/.github/actions/automate-container-scan/README.md
+++ b/.github/actions/automate-container-scan/README.md
@@ -20,6 +20,8 @@ This action provides automated vulnerability scanning for Chef Automate's embedd
   uses: chef/common-github-actions/.github/actions/automate-container-scan@main
   with:
     channel: current
+    license_id: ${{ secrets.GA_DOWNLOAD_GRYPE_LICENSE_ID }}
+    hab_auth_token: ${{ secrets.HAB_AUTH_TOKEN }}  # Required for dev channel
     out_dir: out
 ```
 
@@ -48,6 +50,8 @@ jobs:
         uses: ./common-github-actions/.github/actions/automate-container-scan
         with:
           channel: current
+          license_id: ${{ secrets.GA_DOWNLOAD_GRYPE_LICENSE_ID }}
+          hab_auth_token: ${{ secrets.HAB_AUTH_TOKEN }}
           out_dir: out
       
       - name: Upload scan results
@@ -66,7 +70,11 @@ jobs:
 | Input | Description | Required | Default |
 |-------|-------------|----------|---------|
 | `channel` | Release channel for Chef Automate (`stable` or `current`) | No | `current` |
+| `license_id` | Chef download license ID (required for commercial downloads) | Yes | N/A |
+| `hab_auth_token` | Habitat Builder Personal Access Token for protected channels (pass via secrets) | No | `""` |
 | `out_dir` | Output directory for scan results and logs | No | `out` |
+
+**Note on `hab_auth_token`**: This parameter is **required for the `dev` channel** and other protected Habitat channels that contain packages requiring authentication. The `current` and `stable` channels typically have public packages that don't require authentication. If you see `401 Unauthorized` errors during deployment, ensure you've provided a valid HAB_AUTH_TOKEN.
 
 ## Outputs
 

--- a/.github/actions/automate-container-scan/action.yml
+++ b/.github/actions/automate-container-scan/action.yml
@@ -10,6 +10,10 @@ inputs:
   license_id:
     description: "Chef download license ID (required for commercial downloads)"
     required: true
+  hab_auth_token:
+    description: "Habitat Builder Personal Access Token for protected channels (pass via secrets)"
+    required: false
+    default: ""
   out_dir:
     description: "Output directory for scan results and logs"
     required: false
@@ -33,6 +37,7 @@ runs:
         CHANNEL: ${{ inputs.channel }}
         OUT_DIR: ${{ inputs.out_dir }}
         ACTION_DIR: ${{ github.action_path }}
+        HAB_AUTH_TOKEN: ${{ inputs.hab_auth_token }}
 
 branding:
   icon: "shield"

--- a/.github/actions/automate-container-scan/run.sh
+++ b/.github/actions/automate-container-scan/run.sh
@@ -113,13 +113,20 @@ deploy_automate() {
     log "Deploying Automate (this may take 10-15 minutes)..."
     log "Progress will be logged to ${LOGS_DIR}/deploy.log"
     
+    # Build docker exec command with optional HAB_AUTH_TOKEN
+    local docker_exec_cmd="docker exec -w /root"
+    if [[ -n "${HAB_AUTH_TOKEN:-}" ]]; then
+        log "HAB_AUTH_TOKEN provided - enabling Habitat authentication"
+        docker_exec_cmd="${docker_exec_cmd} -e HAB_AUTH_TOKEN=${HAB_AUTH_TOKEN}"
+    fi
+    docker_exec_cmd="${docker_exec_cmd} ${CONTAINER_ID} timeout 1800 chef-automate deploy --channel ${CHANNEL} --skip-preflight config.toml --accept-terms-and-mlsa"
+    
     # Run deploy with timeout and capture output
     # tee streams output to Actions log in real-time while also writing to file
     # --skip-preflight: the CLI is always downloaded from the 'current' channel (no 'dev' download URL
     # exists), so when deploying --channel dev the preflight CLI version check will always fail because
     # dev has a newer build than current. The skip is safe: the CLI is still fully capable of deploying.
-    if docker exec -w /root "${CONTAINER_ID}" timeout 1800 chef-automate deploy --channel ${CHANNEL} --skip-preflight config.toml --accept-terms-and-mlsa \
-        2>&1 | tee "${LOGS_DIR}/deploy.log"; then
+    if eval "${docker_exec_cmd}" 2>&1 | tee "${LOGS_DIR}/deploy.log"; then
         log "Automate deployment completed successfully"
     else
         log "ERROR: Automate deployment failed or timed out"

--- a/.github/actions/automate-container-scan/run.sh
+++ b/.github/actions/automate-container-scan/run.sh
@@ -109,17 +109,26 @@ deploy_automate() {
         fail "sysctl configuration failed"
     fi
     
+    # Configure Habitat authentication if token provided
+    if [[ -n "${HAB_AUTH_TOKEN:-}" ]]; then
+        log "HAB_AUTH_TOKEN provided - configuring Habitat authentication"
+        # Create Habitat CLI config directory and config file with auth token
+        # This ensures the token is available to all hab processes, including those spawned by systemd
+        docker exec -w /root "${CONTAINER_ID}" bash -c "mkdir -p /hab/etc && cat > /hab/etc/cli.toml <<EOF
+auth_token = \"${HAB_AUTH_TOKEN}\"
+EOF" > "${LOGS_DIR}/hab-config.log" 2>&1 || log "WARNING: Failed to configure Habitat auth (may not be critical)"
+        
+        # Also set as environment variable for immediate processes
+        docker exec -w /root "${CONTAINER_ID}" bash -c "echo 'export HAB_AUTH_TOKEN=${HAB_AUTH_TOKEN}' >> /root/.bashrc" \
+            >> "${LOGS_DIR}/hab-config.log" 2>&1 || true
+    fi
+    
     # Deploy Automate (this takes 10-15 minutes)
     log "Deploying Automate (this may take 10-15 minutes)..."
     log "Progress will be logged to ${LOGS_DIR}/deploy.log"
     
-    # Build docker exec command with optional HAB_AUTH_TOKEN
-    local docker_exec_cmd="docker exec -w /root"
-    if [[ -n "${HAB_AUTH_TOKEN:-}" ]]; then
-        log "HAB_AUTH_TOKEN provided - enabling Habitat authentication"
-        docker_exec_cmd="${docker_exec_cmd} -e HAB_AUTH_TOKEN=${HAB_AUTH_TOKEN}"
-    fi
-    docker_exec_cmd="${docker_exec_cmd} ${CONTAINER_ID} timeout 1800 chef-automate deploy --channel ${CHANNEL} --skip-preflight config.toml --accept-terms-and-mlsa"
+    # Run deploy command
+    local docker_exec_cmd="docker exec -w /root ${CONTAINER_ID} timeout 1800 chef-automate deploy --channel ${CHANNEL} --skip-preflight config.toml --accept-terms-and-mlsa"
     
     # Run deploy with timeout and capture output
     # tee streams output to Actions log in real-time while also writing to file


### PR DESCRIPTION
## Description

Adds Habitat Builder authentication support to the `automate-container-scan` composite action to enable scanning of protected Habitat channels (e.g., `dev`).

### Problem
The `dev` channel automate container scan workflow began failing on April 22, 2026 with `401 Unauthorized` errors when attempting to download Habitat packages during Chef Automate deployment:

```
Error: failed to install package "chef/automate-es-gateway/0.1.0/20260421182556"
↓ Downloading core/libedit/20250104-3.1/20250627184159 for x86_64-linux
✗✗✗ Last error: [401 Unauthorized] 
✗✗✗ Please check that you have specified a valid Personal Access Token.
```

This appears to be new behavior where `dev` channel Habitat packages now require authentication, while `current` channel packages remain publicly accessible.

### Solution
1. **Added `hab_auth_token` input parameter** to the action definition
2. **Configured Habitat authentication** by writing the token to `/hab/etc/cli.toml` before Chef Automate deployment
   - This ensures the token persists for all Habitat processes, including those spawned by systemd
   - Initial approach using `docker exec -e HAB_AUTH_TOKEN` didn't work because systemd services don't inherit environment variables
3. **Updated documentation** with usage examples and notes about when the token is required

### Changes
- `.github/actions/automate-container-scan/action.yml` - Added `hab_auth_token` input and environment variable
- `.github/actions/automate-container-scan/run.sh` - Configure token in Habitat CLI config before deployment
- `.github/actions/automate-container-scan/README.md` - Document new parameter and usage

### Backward Compatibility
✅ Fully backward compatible - channels that don't require authentication continue to work without the token parameter.

## Related Issue

This fixes the automate-grype-scan workflow failure discovered on April 22, 2026 when the `dev` channel job failed while `current` succeeded. This appears to be a new authentication requirement for the `dev` channel Habitat packages.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:

- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

## Testing

Tested with both channels in the automate-grype-scan workflow:
- ✅ `current` channel: Continues to work (backward compatible, no token required)
- ✅ `dev` channel: Now successfully deploys and scans with HAB_AUTH_TOKEN provided

## Notes

The `HAB_AUTH_TOKEN` secret was already configured in the repository for existing Habitat package scanning workflows, so no additional secret setup is needed for users of this action.
