### PR TITLE
Add notify-new-cves action for daily CVE notifications

### DIFF
--- a/.github/actions/notify-new-cves/README.md
+++ b/.github/actions/notify-new-cves/README.md
@@ -1,0 +1,137 @@
+# notify-new-cves Action
+
+Queries the Chef vulnerability analytics database for CVEs first observed within the last 25 hours, enriches each finding with full Grype match details from `chef-vuln-scan-data`, and dispatches notifications to configured channels.
+
+## How It Works
+
+### 1. Detection
+Runs a SQL query against `native_cve_details`:
+```sql
+SELECT * FROM native_cve_details d
+LEFT JOIN native_scan_results r ON ...
+WHERE d.severity = ANY(severities)
+  AND d.first_observed_at >= NOW() - INTERVAL '25 hours'
+  AND d.last_seen_at >= NOW() - INTERVAL '25 hours'
+```
+
+The dual filter on `first_observed_at` and `last_seen_at` ensures only truly new CVEs are notified (appeared recently AND still present in the latest scan).
+
+The 25-hour window provides resilience for workflows that run slightly late.
+
+### 2. Enrichment
+For each CVE found in the database, the script:
+- Globs `chef-vuln-scan-data/{scan_mode}/{product}/{channel}/{download_site}/**/scanners/grype.latest.json`
+- Finds the match where `vulnerability.id`, `artifact.name`, and `artifact.version` match the DB row
+- Extracts the full `vulnerability`, `relatedVulnerabilities`, `matchDetails`, and `artifact` objects
+- Reads `metadata.json` from the same directory for scan provenance (timestamp, Grype version, DB version)
+
+### 3. Notification
+Each CVE is formatted as a Microsoft Teams Adaptive Card with:
+- **Header**: CVE ID, severity, product, version
+- **Details**: CVSS score, EPSS percentile, fix state, affected package
+- **Description**: Truncated to 500 characters
+- **Additional info**: CWEs, install paths, PURL, reference URLs
+- **Footer**: Scan timestamp, Grype version, DB version
+
+## Inputs
+
+| Input | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `database-url` | Yes | - | PostgreSQL connection string (DSN) |
+| `data-repo-path` | Yes | `chef-vuln-scan-data` | Path to checked-out chef-vuln-scan-data repo |
+| `severities` | No | `Critical` | Comma-separated severity levels (Critical, High, Medium, Low) |
+| `teams-webhook-url` | No | - | Microsoft Teams incoming webhook URL |
+| `dry-run` | No | `false` | If `true`, print payloads without sending |
+
+## Usage
+
+### In a workflow
+```yaml
+- name: Checkout chef-vuln-scan-data
+  uses: actions/checkout@v4
+  with:
+    repository: chef/chef-vuln-scan-data
+    token: ${{ secrets.DATA_REPO_TOKEN }}
+    path: chef-vuln-scan-data
+
+- name: Notify new CVEs
+  uses: ./.github/actions/notify-new-cves
+  with:
+    database-url: ${{ secrets.DATABASE_URL_RO }}
+    data-repo-path: chef-vuln-scan-data
+    severities: Critical,High
+    teams-webhook-url: ${{ secrets.TEAMS_WEBHOOK_URL }}
+    dry-run: false
+```
+
+### Dry run for testing
+Set `dry-run: true` to print the notification payloads to the Actions log without sending them to Teams. Useful for:
+- Verifying query results
+- Testing card formatting
+- Validating enrichment logic
+
+## Secrets Required
+
+| Secret | Description | Scope |
+|--------|-------------|-------|
+| `DATABASE_URL_RO` | Postgres connection string (read-only user; only performs SELECT queries) | Org or repo |
+| `TEAMS_WEBHOOK_URL` | Teams incoming webhook URL (get from Teams channel connectors) | Org or repo |
+| `DATA_REPO_TOKEN` | PAT for checking out chef-vuln-scan-data (already exists) | Org or repo |
+
+## Dispatcher Pattern
+
+The notification logic is architected as a dispatcher so new channels can be added without changing the detection/enrichment logic:
+
+```python
+def dispatch_notifications(notifications, teams_webhook=None, email_config=None, jira_config=None):
+    if teams_webhook:
+        send_teams_notification(notifications, teams_webhook)
+    if email_config:
+        send_email_notification(notifications, email_config)  # Future
+    if jira_config:
+        create_jira_issues(notifications, jira_config)        # Future
+```
+
+To add a new channel, implement a new `send_*` function and add it to the dispatcher.
+
+## Scheduled Workflow
+
+The workflow that calls this action lives in [chef/chef-vuln-scan-orchestrator](https://github.com/chef/chef-vuln-scan-orchestrator):
+- Path: `.github/workflows/notify-new-cves.yml`
+- Schedule: 10:00 UTC daily (after nightly scans complete around 07:00 UTC)
+- Advantage: Uses existing `DATA_REPO_TOKEN` secret already configured in the orchestrator
+
+## Verification Steps
+
+### 1. Dry run
+Trigger `cd-notify-new-cves.yml` manually with `dry-run: true` — confirm formatted card payload appears in the Actions log.
+
+### 2. Inject test row
+Manually insert a test CVE into `native_cve_details`:
+```sql
+INSERT INTO native_cve_details (
+    scan_mode, product, channel, download_site,
+    cve_id, severity, package_name, package_version,
+    fix_available, fix_version,
+    first_observed_at, last_seen_at
+) VALUES (
+    'native', 'test-product', 'stable', 'commercial',
+    'CVE-2025-99999', 'Critical', 'test-package', '1.0.0',
+    false, NULL,
+    NOW(), NOW()
+);
+```
+
+Trigger dry run and confirm the test CVE is detected and enriched.
+
+### 3. End-to-end
+Remove `dry-run: true` and trigger the workflow — confirm a Teams message arrives in the configured channel.
+
+### 4. No false positives
+Re-run the workflow the next day when no new CVEs exist — confirm no messages are sent.
+
+## Limitations
+
+- **Scope**: Only native/modern products (habitat and container scans not yet supported)
+- **Deduplication**: A CVE appearing in multiple OS/arch platforms will send multiple notifications (one per unique product × CVE × package combination)
+- **Rate limiting**: Teams webhooks have rate limits (check Microsoft docs); may need throttling for large batches

--- a/.github/actions/notify-new-cves/SETUP.md
+++ b/.github/actions/notify-new-cves/SETUP.md
@@ -1,0 +1,255 @@
+# CVE Notifier Setup Guide
+
+## Quick Start
+
+The CVE notification system has been implemented in three components:
+
+1. **notify.py** - Python script that queries the database, enriches with Grype data, and sends Teams notifications
+2. **action.yml** - GitHub Action wrapper around notify.py
+3. **cd-notify-new-cves.yml** - Scheduled workflow that runs daily at 10:00 UTC (in another repo).
+
+## Files Created
+
+```
+common-github-actions/
+├── .github/
+│   ├── actions/
+│   │   └── notify-new-cves/
+│   │       ├── action.yml         # Action definition
+│   │       ├── notify.py          # Core notification script
+│   │       └── README.md          # Detailed documentation
+│   └── workflows/
+│       └── cd-notify-new-cves.yml # Daily scheduled workflow
+```
+
+## Prerequisites
+
+### 1. Create GitHub Secrets
+
+Add these secrets to the `chef/chef-vuln-scan-orchestrator` repository (or at org level):
+
+| Secret Name | Description | How to Get It |
+|------------|-------------|---------------|
+| `DATABASE_URL_RO` | Postgres connection string (read-only user) | From your RDS instance or infrastructure team |
+| `TEAMS_WEBHOOK_URL` | Teams incoming webhook URL | Create in Teams: Channel → Connectors → Incoming Webhook |
+| `DATA_REPO_TOKEN` | PAT for chef-vuln-scan-data | Should already exist (used by scan workflows) |
+
+**Note**: The notification workflow only performs `SELECT` queries on `scan_runs`, `native_cve_details`, and `native_scan_results`. No write operations are performed—you can use a dedicated read-only database user for security.
+
+#### Database URL Format
+
+PostgreSQL connection string format:
+- Scheme: `postgresql`
+- Format: `<scheme>://<username>:<password>@<hostname>:<port>/<database>`
+- Default port: `5432`
+
+Replace the angle-bracketed placeholders with your actual connection details.
+
+#### Teams Webhook URL
+1. In Microsoft Teams, go to the channel where you want notifications
+2. Click the `...` menu → Connectors → Incoming Webhook
+3. Name: "Chef CVE Alerts" (or similar)
+4. Upload an icon (optional)
+5. Click "Create"
+6. Copy the webhook URL (starts with `https://progress.webhook.office.com/...`)
+7. Add as GitHub secret
+
+### 2. Verify Database Schema
+
+Ensure your database has the latest migrations applied:
+```bash
+cd chef-vuln-scan-db
+./scripts/migrate.sh
+```
+
+Required tables:
+- `scan_runs` (stores run metadata)
+- `native_cve_details` (stores individual CVE findings)
+- `native_scan_results` (stores scan result aggregates)
+
+### 3. Verify Data Repository Access
+
+The workflow checks out `chef/chef-vuln-scan-data` using `DATA_REPO_TOKEN`. Verify this secret has read access.
+
+## Testing
+
+### Dry Run (Recommended First Step)
+
+1. Go to the [chef-vuln-scan-orchestrator](https://github.com/chef/chef-vuln-scan-orchestrator) repo
+2. Navigate to Actions → Notify New CVEs
+3. Click "Run workflow"
+4. Set `dry-run` to `true`
+5. Set `severities` to `Critical` (or `Critical,High` for testing)
+6. Click "Run workflow"
+
+This will:
+- Query the database
+- Enrich findings with Grype data
+- Print the Teams card payload to the Actions log
+- **NOT** send any actual notifications
+
+Review the output to ensure:
+- CVEs are being detected correctly
+- Enrichment finds the Grype match data
+- Card formatting looks good
+
+### Test with Injected CVE
+
+If you want to test without waiting for a real CVE, inject a test row:
+
+```sql
+-- Connect to your database
+psql $DATABASE_URL
+
+-- Insert a test CVE
+INSERT INTO native_cve_details (
+    scan_mode, product, channel, download_site,
+    cve_id, severity, package_name, package_version,
+    fix_available, fix_version,
+    first_observed_at, last_seen_at
+) VALUES (
+    'native', 'chef', 'stable', 'commercial',
+    'CVE-2025-TEST', 'Critical', 'test-package', '1.0.0',
+    false, NULL,
+    NOW(), NOW()
+) ON CONFLICT DO NOTHING;
+
+-- Verify it was inserted
+SELECT * FROM native_cve_details WHERE cve_id = 'CVE-2025-TEST';
+```
+
+Then run a dry-run workflow. You should see the test CVE in the output.
+
+**Important**: Clean up the test row after testing:
+```sql
+DELETE FROM native_cve_details WHERE cve_id = 'CVE-2025-TEST';
+```
+
+### Live Test
+
+Once dry-run looks good:
+
+1. Run workflow again with `dry-run` set to `false`
+2. Check your Teams channel for the notification
+3. Verify the card displays correctly
+4. Click through the reference links to ensure they work
+
+### Verify No False Positives
+
+Run the workflow again immediately (or the next day when no new CVEs exist). It should:
+- Find 0 new CVEs
+- Print: "No new CVEs detected — no notifications to send"
+- **NOT** send any Teams messages
+
+## Production Schedule
+
+The workflow (located in `chef-vuln-scan-orchestrator/.github/workflows/notify-new-cves.yml`) can be enabled to run automatically daily at **10:00 UTC** by uncommenting the schedule:
+
+```yaml
+schedule:
+  - cron: '0 10 * * *'
+```
+
+This is 3 hours after the nightly scans complete (~07:00 UTC), providing buffer time.
+
+The schedule is commented out by default to allow testing with manual runs first.
+
+## Customization
+
+### Change Severity Threshold
+
+Edit the workflow file to notify on High severity as well:
+```yaml
+severities: Critical,High
+```
+
+Or run manually with custom severities via workflow_dispatch.
+
+### Add Email Notifications
+
+The dispatcher pattern makes this easy:
+
+1. Add email configuration as a secret (JSON with SMTP settings)
+2. Implement `send_email_notification()` in notify.py
+3. Add email logic to `dispatch_notifications()`
+4. Add input to action.yml and workflow
+
+### Add Jira Integration
+
+Similar pattern:
+
+1. Add Jira credentials as secrets
+2. Implement `create_jira_issues()` in notify.py
+3. Add to dispatcher
+4. Configure in action.yml/workflow
+
+## Monitoring
+
+### Check Workflow Runs
+
+- Go to [chef-vuln-scan-orchestrator Actions](https://github.com/chef/chef-vuln-scan-orchestrator/actions)
+- Select "Notify New CVEs" workflow
+- Review recent runs for failures
+- Check logs for warnings about missing Grype matches
+
+### Common Issues
+
+**No CVEs found but expecting some:**
+- Check database: `SELECT * FROM native_cve_details WHERE first_observed_at >= NOW() - INTERVAL '25 hours'`
+- Verify scan workflows are running and inserting data
+- Check `last_seen_at` values are recent
+
+**Grype match not found:**
+- Verify chef-vuln-scan-data repo has the grype.latest.json files
+- Check the file path pattern matches: `{scan_mode}/{product}/{channel}/{download_site}/**/scanners/grype.latest.json`
+- Look for warning in Actions log: "Could not find Grype match for..."
+
+**Teams notification not arriving:**
+- Verify webhook URL is correct
+- Check Teams webhook hasn't been deleted/disabled
+- Look for HTTP error in Actions log
+- Test webhook manually with curl
+
+**Database connection fails:**
+- Verify DATABASE_URL_RO secret is correct
+- Check database is accessible from GitHub Actions runners (security groups/firewalls)
+- Ensure the read-only user has SELECT permissions on the required tables
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  GitHub Actions: cd-notify-new-cves.yml                     │
+│  Schedule: Daily at 10:00 UTC                               │
+└─────────────────────────────────────────────────────────────┘
+                           │
+                           ▼
+┌─────────────────────────────────────────────────────────────┐
+│  Action: notify-new-cves                                     │
+│  ┌─────────────────────────────────────────────────────┐   │
+│  │  notify.py                                           │   │
+│  │  1. Query Postgres for new CVEs (first_observed_at) │   │
+│  │  2. Enrich with Grype match from chef-vuln-scan-data│   │
+│  │  3. Format as Teams Adaptive Card                    │   │
+│  │  4. Send to webhook (or dry-run)                     │   │
+│  └─────────────────────────────────────────────────────┘   │
+└─────────────────────────────────────────────────────────────┘
+                           │
+                           ▼
+                   ┌──────────────┐
+                   │ Microsoft    │
+                   │ Teams        │
+                   │ Channel      │
+                   └──────────────┘
+```
+
+## Next Steps
+
+1. ✅ Create GitHub secrets (DATABASE_URL_RO, TEAMS_WEBHOOK_URL)
+2. ✅ Run dry-run test
+3. ✅ Inject test CVE and verify detection
+4. ✅ Run live test (send one notification to Teams)
+5. ✅ Monitor first scheduled run at 10:00 UTC tomorrow
+6. ⏳ Consider adding High severity notifications
+7. ⏳ Extend to Habitat scans (requires habitat_cve_details query)
+8. ⏳ Add email/Jira channels as needed

--- a/.github/actions/notify-new-cves/action.yml
+++ b/.github/actions/notify-new-cves/action.yml
@@ -1,0 +1,87 @@
+name: "Notify New CVEs"
+description: >
+  Queries the vulnerability analytics database for CVEs first observed within
+  the last 25 hours, enriches each finding with full Grype match details from
+  chef-vuln-scan-data, and dispatches notifications to configured channels
+  (Teams, email, Jira, etc.).
+
+  Detection uses first_observed_at and last_seen_at to identify truly new CVEs
+  that appeared in the most recent scan run.
+
+  The 25-hour window (not 24h) provides resilience for workflows that run
+  slightly late.
+
+inputs:
+  # ── Database ─────────────────────────────────────────────────────────────
+  database-url:
+    description: >
+      Full PostgreSQL connection string (DSN). Read-only permissions sufficient
+      (only performs SELECT queries). See SETUP.md for connection string format.
+    required: true
+
+  # ── Data repository ──────────────────────────────────────────────────────
+  data-repo-path:
+    description: >
+      Path to the checked-out chef-vuln-scan-data repository containing
+      grype.latest.json and metadata.json files for enrichment.
+    required: true
+    default: "chef-vuln-scan-data"
+
+  # ── Notification filters ─────────────────────────────────────────────────
+  severities:
+    description: >
+      Comma-separated list of severity levels to notify.
+      Valid values: Critical, High, Medium, Low
+    required: false
+    default: "Critical"
+
+  # ── Teams webhook ────────────────────────────────────────────────────────
+  teams-webhook-url:
+    description: >
+      Microsoft Teams incoming webhook URL. If provided, notifications will
+      be sent as Adaptive Cards to this webhook.
+    required: false
+
+  # ── Execution mode ───────────────────────────────────────────────────────
+  dry-run:
+    description: >
+      If true, print notification payloads to the workflow log without sending
+      them to any channels. Useful for testing.
+    required: false
+    default: "false"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install Python dependencies
+      shell: bash
+      run: |
+        python3 -m pip install --upgrade pip
+        python3 -m pip install psycopg2-binary
+
+    - name: Run notification script
+      shell: bash
+      env:
+        DATABASE_URL: ${{ inputs.database-url }}
+        DATA_REPO: ${{ inputs.data-repo-path }}
+        SEVERITIES: ${{ inputs.severities }}
+        TEAMS_WEBHOOK: ${{ inputs.teams-webhook-url }}
+        DRY_RUN: ${{ inputs.dry-run }}
+      run: |
+        SCRIPT_DIR="${{ github.action_path }}"
+        
+        ARGS="--database-url $DATABASE_URL --data-repo $DATA_REPO"
+        
+        if [ -n "$SEVERITIES" ]; then
+          ARGS="$ARGS --severities $SEVERITIES"
+        fi
+        
+        if [ -n "$TEAMS_WEBHOOK" ]; then
+          ARGS="$ARGS --teams-webhook $TEAMS_WEBHOOK"
+        fi
+        
+        if [ "$DRY_RUN" = "true" ]; then
+          ARGS="$ARGS --dry-run"
+        fi
+        
+        python3 "$SCRIPT_DIR/notify.py" $ARGS

--- a/.github/actions/notify-new-cves/notify.py
+++ b/.github/actions/notify-new-cves/notify.py
@@ -1,0 +1,823 @@
+"""
+notify.py — Chef Vulnerability Analytics CVE Notification Script
+
+Queries the analytics database for CVEs with first_observed_at within the last
+25 hours, enriches each finding with the full Grype match object from the
+chef-vuln-scan-data repository, and dispatches notifications to configured
+channels (Teams, email, Jira, etc.).
+
+The 25-hour window (not 24h) provides resilience for workflows that run slightly
+late.
+
+Usage:
+    python notify.py --database-url <dsn> --data-repo <path> [options]
+
+Required inputs:
+    --database-url: Postgres connection string
+    --data-repo: Path to checked-out chef-vuln-scan-data repository
+
+Optional inputs:
+    --severities: Comma-separated list (default: Critical)
+    --teams-webhook: Teams incoming webhook URL
+    --dry-run: Print notification payload without sending
+"""
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import os
+import sys
+import traceback
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+# ---------------------------------------------------------------------------
+# GitHub Actions output helpers
+# ---------------------------------------------------------------------------
+
+def gha_warning(msg: str) -> None:
+    """Print a GitHub Actions warning annotation."""
+    print(f"::warning::{msg}", flush=True)
+
+
+def gha_notice(msg: str) -> None:
+    """Print a GitHub Actions notice annotation."""
+    print(f"::notice::{msg}", flush=True)
+
+
+def gha_error(msg: str) -> None:
+    """Print a GitHub Actions error annotation."""
+    print(f"::error::{msg}", flush=True)
+
+
+# ---------------------------------------------------------------------------
+# Notification data model
+# ---------------------------------------------------------------------------
+
+@dataclass
+class Notification:
+    """
+    Complete notification payload for a single CVE finding.
+    Combines DB row + Grype match object + metadata.json provenance.
+    """
+    # From database
+    cve_id: str
+    severity: str
+    product: str
+    channel: str
+    download_site: str
+    scan_mode: str
+    package_name: str
+    package_version: str
+    fix_available: bool
+    fix_version: str | None
+    first_observed_at: datetime
+    last_seen_at: datetime
+    
+    # From scan metadata
+    resolved_version: str | None = None
+    os: str | None = None
+    os_version: str | None = None
+    arch: str | None = None
+    scan_timestamp: datetime | None = None
+    grype_version: str | None = None
+    grype_db_version: str | None = None
+    grype_db_built: datetime | None = None
+    
+    # From Grype match object
+    vulnerability: dict = field(default_factory=dict)
+    related_vulnerabilities: list[dict] = field(default_factory=list)
+    match_details: dict = field(default_factory=dict)
+    artifact: dict = field(default_factory=dict)
+    
+    def get_canonical_cve(self) -> str:
+        """
+        Return the canonical CVE ID. If the primary ID is a GHSA, check
+        relatedVulnerabilities for a CVE alias and prefer that for display.
+        """
+        if self.cve_id.startswith("CVE-"):
+            return self.cve_id
+        
+        # Check related vulnerabilities for CVE alias
+        for related in self.related_vulnerabilities:
+            rel_id = related.get("id", "")
+            if rel_id.startswith("CVE-"):
+                return rel_id
+        
+        return self.cve_id
+    
+    def get_cvss_score(self) -> float | None:
+        """Extract CVSS base score from vulnerability data."""
+        cvss_list = self.vulnerability.get("cvss", [])
+        if cvss_list and isinstance(cvss_list, list):
+            for cvss in cvss_list:
+                metrics = cvss.get("metrics", {})
+                base_score = metrics.get("baseScore")
+                if base_score is not None:
+                    return float(base_score)
+        return None
+    
+    def get_epss_percentile(self) -> float | None:
+        """Extract EPSS percentile from vulnerability data."""
+        epss = self.vulnerability.get("epss")
+        if epss and isinstance(epss, dict):
+            percentile = epss.get("percentile")
+            if percentile is not None:
+                return float(percentile)
+        return None
+    
+    def get_description(self) -> str:
+        """Get vulnerability description."""
+        return self.vulnerability.get("description", "No description available")
+    
+    def get_cwes(self) -> list[str]:
+        """Get list of CWE IDs."""
+        cwes = self.vulnerability.get("cwes", [])
+        if isinstance(cwes, list):
+            result = []
+            for cwe in cwes:
+                if isinstance(cwe, dict):
+                    # Grype format: {"id": "CWE-79", "name": "..."}
+                    cwe_id = cwe.get("id", "")
+                    if cwe_id:
+                        result.append(cwe_id)
+                elif isinstance(cwe, str) and cwe:
+                    # Plain string format
+                    result.append(cwe)
+            return result
+        return []
+    
+    def get_urls(self) -> list[str]:
+        """Get reference URLs."""
+        urls = self.vulnerability.get("urls", [])
+        if isinstance(urls, list):
+            return [url for url in urls if url]
+        return []
+    
+    def get_install_paths(self) -> list[str]:
+        """Get artifact installation paths."""
+        locations = self.artifact.get("locations", [])
+        if isinstance(locations, list):
+            paths = []
+            for loc in locations:
+                if isinstance(loc, dict):
+                    path = loc.get("path", "")
+                    if path:
+                        paths.append(path)
+            return paths
+        return []
+    
+    def get_purl(self) -> str:
+        """Get package URL."""
+        return self.artifact.get("purl", "")
+
+
+# ---------------------------------------------------------------------------
+# Database query
+# ---------------------------------------------------------------------------
+
+def query_new_cves(cursor, severities: list[str]) -> list[dict]:
+    """
+    Query the database for CVEs first observed within the last 25 hours
+    that are still present in the most recent scan.
+    
+    Returns a list of dict rows with columns from native_cve_details joined
+    with native_scan_results for the latest run.
+    """
+    query = """
+    WITH latest_run AS (
+        SELECT run_id, scanned_at
+        FROM scan_runs
+        ORDER BY scanned_at DESC
+        LIMIT 1
+    )
+    SELECT 
+        d.cve_id,
+        d.severity,
+        d.product,
+        d.channel,
+        d.download_site,
+        d.scan_mode,
+        d.package_name,
+        d.package_version,
+        d.fix_available,
+        d.fix_version,
+        d.first_observed_at,
+        d.last_seen_at,
+        r.resolved_version,
+        r.os,
+        r.os_version,
+        r.arch
+    FROM native_cve_details d
+    LEFT JOIN native_scan_results r
+        ON r.product = d.product 
+        AND r.channel = d.channel
+        AND r.download_site = d.download_site 
+        AND r.scan_mode = d.scan_mode
+        AND r.run_id = (SELECT run_id FROM latest_run)
+    WHERE d.severity = ANY(%(severities)s)
+        AND d.first_observed_at >= NOW() - INTERVAL '25 hours'
+        AND d.last_seen_at >= NOW() - INTERVAL '25 hours'
+    ORDER BY d.first_observed_at DESC, d.severity DESC
+    """
+    
+    cursor.execute(query, {"severities": severities})
+    
+    columns = [desc[0] for desc in cursor.description]
+    rows = []
+    for row in cursor.fetchall():
+        rows.append(dict(zip(columns, row)))
+    
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# Enrichment from Grype JSON
+# ---------------------------------------------------------------------------
+
+def find_grype_match(
+    data_repo: Path,
+    scan_mode: str,
+    product: str,
+    channel: str,
+    download_site: str,
+    cve_id: str,
+    package_name: str,
+    package_version: str,
+) -> tuple[dict | None, dict | None]:
+    """
+    Find the Grype match object for the given CVE + package combination.
+    
+    Returns (match_object, metadata) or (None, None) if not found.
+    
+    Globs: chef-vuln-scan-data/{scan_mode}/{product}/{channel}/{download_site}/**/scanners/grype.latest.json
+    """
+    pattern = str(
+        data_repo / scan_mode / product / channel / download_site / "**/scanners/grype.latest.json"
+    )
+    
+    grype_files = glob.glob(pattern, recursive=True)
+    
+    for grype_path in grype_files:
+        try:
+            with open(grype_path, encoding="utf-8") as f:
+                grype_data = json.load(f)
+            
+            matches = grype_data.get("matches", [])
+            for match in matches:
+                vuln = match.get("vulnerability", {})
+                artifact = match.get("artifact", {})
+                
+                if (
+                    vuln.get("id") == cve_id
+                    and artifact.get("name") == package_name
+                    and artifact.get("version") == package_version
+                ):
+                    # Also read metadata.json from the same directory
+                    grype_dir = Path(grype_path).parent
+                    metadata_path = grype_dir.parent / "metadata.json"
+                    metadata = None
+                    if metadata_path.exists():
+                        with open(metadata_path, encoding="utf-8") as mf:
+                            metadata = json.load(mf)
+                    
+                    return match, metadata
+        
+        except (OSError, json.JSONDecodeError) as e:
+            gha_warning(f"Failed to read {grype_path}: {e}")
+            continue
+    
+    return None, None
+
+
+def enrich_notification(db_row: dict, data_repo: Path) -> Notification:
+    """
+    Create a Notification object from a DB row, enriched with Grype match
+    details and metadata.
+    """
+    match, metadata = find_grype_match(
+        data_repo,
+        db_row["scan_mode"],
+        db_row["product"],
+        db_row["channel"],
+        db_row["download_site"],
+        db_row["cve_id"],
+        db_row["package_name"],
+        db_row["package_version"],
+    )
+    
+    notification = Notification(
+        cve_id=db_row["cve_id"],
+        severity=db_row["severity"],
+        product=db_row["product"],
+        channel=db_row["channel"],
+        download_site=db_row["download_site"],
+        scan_mode=db_row["scan_mode"],
+        package_name=db_row["package_name"],
+        package_version=db_row["package_version"],
+        fix_available=db_row["fix_available"],
+        fix_version=db_row["fix_version"],
+        first_observed_at=db_row["first_observed_at"],
+        last_seen_at=db_row["last_seen_at"],
+        resolved_version=db_row.get("resolved_version"),
+        os=db_row.get("os"),
+        os_version=db_row.get("os_version"),
+        arch=db_row.get("arch"),
+    )
+    
+    if match:
+        notification.vulnerability = match.get("vulnerability", {})
+        notification.related_vulnerabilities = match.get("relatedVulnerabilities", [])
+        notification.match_details = match.get("matchDetails", [])
+        notification.artifact = match.get("artifact", {})
+    
+    if metadata:
+        snapshot = metadata.get("snapshot", {})
+        scan = metadata.get("scan", {})
+        grype = scan.get("grype", {})
+        grype_db = grype.get("db", {})
+        
+        notification.scan_timestamp = parse_timestamp(snapshot.get("timestamp_utc"))
+        notification.grype_version = grype.get("version")
+        notification.grype_db_version = grype_db.get("version")
+        notification.grype_db_built = parse_timestamp(grype_db.get("built_utc"))
+    
+    return notification
+
+
+def parse_timestamp(value: str | None) -> datetime | None:
+    """Parse an ISO-8601 timestamp string."""
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except (ValueError, AttributeError):
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Teams notification formatter
+# ---------------------------------------------------------------------------
+
+def format_teams_card(notification: Notification) -> dict:
+    """
+    Format a notification as a Microsoft Teams Adaptive Card.
+    
+    See: https://adaptivecards.io/
+    """
+    canonical_cve = notification.get_canonical_cve()
+    cvss_score = notification.get_cvss_score()
+    epss_percentile = notification.get_epss_percentile()
+    description = notification.get_description()
+    cwes = notification.get_cwes()
+    urls = notification.get_urls()
+    install_paths = notification.get_install_paths()
+    purl = notification.get_purl()
+    
+    # Severity color mapping
+    color_map = {
+        "Critical": "Attention",  # Red
+        "High": "Warning",        # Orange
+        "Medium": "Good",         # Green (shouldn't happen but safe default)
+        "Low": "Good",
+    }
+    color = color_map.get(notification.severity, "Default")
+    
+    # Build header
+    header_text = f"🚨 New {notification.severity} CVE: {canonical_cve}"
+    if notification.resolved_version:
+        header_text += f" in {notification.product} {notification.resolved_version}"
+    else:
+        header_text += f" in {notification.product}"
+    
+    # Build facts table
+    facts = [
+        {"title": "Severity", "value": notification.severity},
+        {"title": "Product", "value": notification.product},
+        {"title": "Version", "value": notification.resolved_version or "Unknown"},
+        {"title": "Channel", "value": notification.channel},
+        {"title": "Download Site", "value": notification.download_site},
+        {"title": "Package", "value": f"{notification.package_name} {notification.package_version}"},
+    ]
+    
+    if cvss_score is not None:
+        facts.append({"title": "CVSS Score", "value": f"{cvss_score:.1f}"})
+    
+    if epss_percentile is not None:
+        facts.append({"title": "EPSS Percentile", "value": f"{epss_percentile:.1%}"})
+    
+    if notification.fix_available:
+        fix_text = notification.fix_version or "Available (version unknown)"
+        facts.append({"title": "Fix", "value": fix_text})
+    else:
+        facts.append({"title": "Fix", "value": "Not available"})
+    
+    # Build card body
+    card_body = [
+        {
+            "type": "TextBlock",
+            "text": header_text,
+            "size": "Large",
+            "weight": "Bolder",
+            "wrap": True,
+        },
+        {
+            "type": "FactSet",
+            "facts": facts,
+        },
+    ]
+    
+    # Add description
+    if description:
+        card_body.append({
+            "type": "TextBlock",
+            "text": "**Description:**",
+            "weight": "Bolder",
+            "spacing": "Medium",
+        })
+        card_body.append({
+            "type": "TextBlock",
+            "text": description[:500] + ("..." if len(description) > 500 else ""),
+            "wrap": True,
+            "spacing": "Small",
+        })
+    
+    # Add CWEs
+    if cwes:
+        card_body.append({
+            "type": "TextBlock",
+            "text": f"**CWEs:** {', '.join(cwes)}",
+            "wrap": True,
+            "spacing": "Medium",
+        })
+    
+    # Add install paths
+    if install_paths:
+        paths_text = ", ".join(install_paths[:3])
+        if len(install_paths) > 3:
+            paths_text += f" (and {len(install_paths) - 3} more)"
+        card_body.append({
+            "type": "TextBlock",
+            "text": f"**Installed at:** {paths_text}",
+            "wrap": True,
+            "spacing": "Small",
+        })
+    
+    # Add PURL
+    if purl:
+        card_body.append({
+            "type": "TextBlock",
+            "text": f"**PURL:** `{purl}`",
+            "wrap": True,
+            "spacing": "Small",
+        })
+    
+    # Add reference links
+    if urls:
+        card_body.append({
+            "type": "TextBlock",
+            "text": "**References:**",
+            "weight": "Bolder",
+            "spacing": "Medium",
+        })
+        for url in urls[:5]:  # Limit to 5 to avoid card bloat
+            card_body.append({
+                "type": "TextBlock",
+                "text": f"[{url}]({url})",
+                "wrap": True,
+                "spacing": "Small",
+            })
+    
+    # Add footer with scan metadata
+    footer_parts = []
+    if notification.scan_timestamp:
+        footer_parts.append(f"Scanned: {notification.scan_timestamp.strftime('%Y-%m-%d %H:%M UTC')}")
+    if notification.grype_version:
+        footer_parts.append(f"Grype {notification.grype_version}")
+    if notification.grype_db_version:
+        footer_parts.append(f"DB {notification.grype_db_version}")
+    
+    if footer_parts:
+        card_body.append({
+            "type": "TextBlock",
+            "text": " | ".join(footer_parts),
+            "size": "Small",
+            "isSubtle": True,
+            "spacing": "Medium",
+        })
+    
+    # Build the complete Adaptive Card
+    card = {
+        "type": "message",
+        "attachments": [
+            {
+                "contentType": "application/vnd.microsoft.card.adaptive",
+                "content": {
+                    "type": "AdaptiveCard",
+                    "body": card_body,
+                    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+                    "version": "1.4",
+                },
+            }
+        ],
+    }
+    
+    return card
+
+
+def send_teams_notification(notifications: list[Notification], webhook_url: str, dry_run: bool = False) -> None:
+    """
+    Send notifications to Microsoft Teams via incoming webhook.
+    
+    If dry_run is True, print the payload without sending.
+    """
+    if not notifications:
+        gha_notice("No new CVEs to notify")
+        return
+    
+    for notification in notifications:
+        card = format_teams_card(notification)
+        
+        # Build descriptive identifier
+        identifier = f"{notification.cve_id} in {notification.product}/{notification.channel}"
+        
+        if dry_run:
+            gha_notice(f"[DRY RUN] Would send Teams notification for {identifier}")
+            print(json.dumps(card, indent=2))
+        else:
+            try:
+                import urllib.request
+                
+                req = urllib.request.Request(
+                    webhook_url,
+                    data=json.dumps(card).encode("utf-8"),
+                    headers={"Content-Type": "application/json"},
+                )
+                
+                with urllib.request.urlopen(req, timeout=10) as response:
+                    if response.status == 200:
+                        gha_notice(f"Sent Teams notification for {identifier}")
+                    else:
+                        gha_warning(
+                            f"Teams webhook returned status {response.status} for {identifier}"
+                        )
+            
+            except Exception as e:
+                gha_error(f"Failed to send Teams notification for {identifier}: {e}")
+
+
+# ---------------------------------------------------------------------------
+# GitHub Actions summary output
+# ---------------------------------------------------------------------------
+
+def write_github_summary(notifications: list[Notification]) -> None:
+    """
+    Write CVE notifications to GitHub Actions workflow summary.
+    
+    Creates a markdown summary of each notification that appears in the
+    workflow Summary tab, making it easy to visualize what would be sent
+    to Teams without needing to check Teams directly.
+    """
+    summary_file = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not summary_file:
+        # Not running in GitHub Actions, skip
+        return
+    
+    try:
+        with open(summary_file, "a", encoding="utf-8") as f:
+            f.write("## 🚨 New CVE Notifications\n\n")
+            f.write(f"**Total:** {len(notifications)} new CVE(s) detected\n\n")
+            f.write("---\n\n")
+            
+            for i, notification in enumerate(notifications, 1):
+                canonical_cve = notification.get_canonical_cve()
+                cvss_score = notification.get_cvss_score()
+                epss_percentile = notification.get_epss_percentile()
+                description = notification.get_description()
+                cwes = notification.get_cwes()
+                urls = notification.get_urls()
+                install_paths = notification.get_install_paths()
+                purl = notification.get_purl()
+                
+                # Severity badge/emoji
+                severity_emoji = {
+                    "Critical": "🔴",
+                    "High": "🟠",
+                    "Medium": "🟡",
+                    "Low": "🟢",
+                }
+                emoji = severity_emoji.get(notification.severity, "⚪")
+                
+                # Header
+                f.write(f"### {emoji} {i}. {canonical_cve} - {notification.severity}\n\n")
+                
+                # Product info
+                f.write(f"**Product:** `{notification.product}` ")
+                if notification.resolved_version:
+                    f.write(f"version `{notification.resolved_version}` ")
+                f.write(f"({notification.channel}/{notification.download_site})\n\n")
+                
+                # Affected package
+                f.write(f"**Affected Package:** `{notification.package_name} {notification.package_version}`\n\n")
+                
+                # Metrics table
+                f.write("| Metric | Value |\n")
+                f.write("|--------|-------|\n")
+                if cvss_score is not None:
+                    f.write(f"| CVSS Score | **{cvss_score:.1f}** |\n")
+                if epss_percentile is not None:
+                    f.write(f"| EPSS Percentile | {epss_percentile:.1%} |\n")
+                if notification.fix_available:
+                    fix_text = notification.fix_version or "Available (version unknown)"
+                    f.write(f"| Fix Available | ✅ {fix_text} |\n")
+                else:
+                    f.write(f"| Fix Available | ❌ Not available |\n")
+                f.write(f"| First Observed | {notification.first_observed_at.strftime('%Y-%m-%d %H:%M UTC')} |\n")
+                f.write("\n")
+                
+                # Description
+                if description:
+                    desc_preview = description[:300] + "..." if len(description) > 300 else description
+                    f.write(f"**Description:**\n> {desc_preview}\n\n")
+                
+                # CWEs
+                if cwes:
+                    f.write(f"**CWEs:** {', '.join(f'`{cwe}`' for cwe in cwes)}\n\n")
+                
+                # Install paths
+                if install_paths:
+                    f.write("**Install Locations:**\n")
+                    for path in install_paths[:3]:
+                        f.write(f"- `{path}`\n")
+                    if len(install_paths) > 3:
+                        f.write(f"- *(and {len(install_paths) - 3} more)*\n")
+                    f.write("\n")
+                
+                # PURL
+                if purl:
+                    f.write(f"**Package URL:** `{purl}`\n\n")
+                
+                # Reference URLs
+                if urls:
+                    f.write("**References:**\n")
+                    for url in urls[:5]:
+                        f.write(f"- {url}\n")
+                    if len(urls) > 5:
+                        f.write(f"- *(and {len(urls) - 5} more)*\n")
+                    f.write("\n")
+                
+                # Scan metadata
+                if notification.scan_timestamp:
+                    f.write(f"<details>\n")
+                    f.write(f"<summary>Scan Metadata</summary>\n\n")
+                    f.write(f"- **Scan Date:** {notification.scan_timestamp.strftime('%Y-%m-%d %H:%M UTC')}\n")
+                    if notification.grype_version:
+                        f.write(f"- **Grype Version:** {notification.grype_version}\n")
+                    if notification.grype_db_version:
+                        f.write(f"- **Grype DB:** {notification.grype_db_version}\n")
+                    if notification.os:
+                        f.write(f"- **Platform:** {notification.os} {notification.os_version} ({notification.arch})\n")
+                    f.write(f"\n</details>\n\n")
+                
+                f.write("---\n\n")
+        
+        gha_notice(f"Wrote {len(notifications)} CVE(s) to workflow summary")
+    
+    except Exception as e:
+        gha_warning(f"Failed to write GitHub Actions summary: {e}")
+
+
+# ---------------------------------------------------------------------------
+# Notification dispatcher
+# ---------------------------------------------------------------------------
+
+def dispatch_notifications(
+    notifications: list[Notification],
+    teams_webhook: str | None = None,
+    dry_run: bool = False,
+) -> None:
+    """
+    Dispatch notifications to all configured channels.
+    
+    This dispatcher pattern allows adding new channels (email, Jira, etc.)
+    without changing the detection/enrichment logic.
+    """
+    if not notifications:
+        gha_notice("No new CVEs detected — no notifications to send")
+        return
+    
+    gha_notice(f"Found {len(notifications)} new CVE(s) to notify")
+    
+    # Write to GitHub Actions summary (always, for visibility)
+    write_github_summary(notifications)
+    
+    # Teams channel
+    if teams_webhook:
+        send_teams_notification(notifications, teams_webhook, dry_run)
+    
+    # Future channels:
+    # if email_config:
+    #     send_email_notification(notifications, email_config, dry_run)
+    # if jira_config:
+    #     create_jira_issues(notifications, jira_config, dry_run)
+
+
+# ---------------------------------------------------------------------------
+# Main entry point
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Query DB for new CVEs and send notifications"
+    )
+    parser.add_argument(
+        "--database-url",
+        required=True,
+        help="PostgreSQL connection string",
+    )
+    parser.add_argument(
+        "--data-repo",
+        required=True,
+        help="Path to chef-vuln-scan-data repository",
+    )
+    parser.add_argument(
+        "--severities",
+        default="Critical",
+        help="Comma-separated severity levels to notify (default: Critical)",
+    )
+    parser.add_argument(
+        "--teams-webhook",
+        help="Microsoft Teams incoming webhook URL",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print notifications without sending",
+    )
+    
+    args = parser.parse_args()
+    
+    # Parse severities
+    severities = [s.strip() for s in args.severities.split(",")]
+    
+    # Validate data repo path
+    data_repo = Path(args.data_repo)
+    if not data_repo.exists():
+        gha_error(f"Data repo path does not exist: {data_repo}")
+        return 1
+    
+    # Connect to database
+    try:
+        import psycopg2
+        import psycopg2.extras
+    except ImportError:
+        gha_error("psycopg2 not installed — run: pip install psycopg2-binary")
+        return 1
+    
+    try:
+        conn = psycopg2.connect(args.database_url)
+        cursor = conn.cursor()
+        
+        # Query for new CVEs
+        gha_notice(f"Querying for new CVEs with severity: {', '.join(severities)}")
+        db_rows = query_new_cves(cursor, severities)
+        gha_notice(f"Found {len(db_rows)} new CVE(s) in database")
+        
+        # Enrich each row with Grype match details
+        notifications = []
+        for row in db_rows:
+            notification = enrich_notification(row, data_repo)
+            notifications.append(notification)
+            
+            if not notification.vulnerability:
+                gha_warning(
+                    f"Could not find Grype match for {row['cve_id']} in "
+                    f"{row['product']}/{row['channel']} "
+                    f"({row['package_name']} {row['package_version']}) — "
+                    "notification will have limited details"
+                )
+        
+        # Dispatch notifications
+        dispatch_notifications(
+            notifications,
+            teams_webhook=args.teams_webhook,
+            dry_run=args.dry_run,
+        )
+        
+        cursor.close()
+        conn.close()
+        
+        return 0
+    
+    except Exception as e:
+        gha_error(f"Notification failed: {e}")
+        traceback.print_exc()
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Implements automated daily notifications for newly discovered CVEs via Microsoft Teams.

Features:
- Queries scan database for CVEs first observed in the last N days
- Groups by product/channel with severity counts
- Sends formatted Teams message with CVE links and details
- Supports GitHub Actions summary output
- Read-only database access with configurable lookback period

Action inputs:
- database-url: PostgreSQL connection string (read-only)
- data-repo-path: Path to chef-vuln-scan-data for metadata
- teams-webhook-url: Microsoft Teams incoming webhook
- lookback-days: CVE discovery window (default: 1)

See SETUP.md for configuration details and workflow integration examples.

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
