### PR TITLE
Ruby erlang fix

### DIFF
--- a/.github/workflows/ci-main-pull-request.yml
+++ b/.github/workflows/ci-main-pull-request.yml
@@ -1593,7 +1593,7 @@ jobs:
       github-branch-name: ${{ inputs.github-branch-name }}
       version: ${{ inputs.version }}
       export-github-sbom: ${{ inputs.export-github-sbom }}
-      perform-blackduck-sca-scan: ${{ inputs.perform-blackduck-sca-scan && github.event_name == 'push' }}
+      perform-blackduck-sca-scan: ${{ inputs.perform-blackduck-sca-scan && (github.event_name == 'push' || github.event_name == 'pull_request') }} # TODO: revert to 'push' only after ruby-erlang testing is complete
       # generate-blackduck-sbom: ${{ inputs.generate-blackduck-sbom }}  # obsolete, remove TODO
       blackduck-project-group-name: ${{ inputs.blackduck-project-group-name }}
       blackduck-project-name: ${{ inputs.blackduck-project-name }}

--- a/.github/workflows/ci-main-pull-request.yml
+++ b/.github/workflows/ci-main-pull-request.yml
@@ -1585,7 +1585,7 @@ jobs:
     name: 'Generating SBOM'
     #    Create software bill-of-materials (SBOM) using SPDX format
     if: ${{ inputs.generate-sbom == true }}
-    uses: chef/common-github-actions/.github/workflows/sbom.yml@main
+    uses: chef/common-github-actions/.github/workflows/sbom.yml@ruby-erlang-fix # TODO: revert to @main after ruby-erlang-fix is merged
     needs: checkout # TODO: fix set-application-version
     secrets: inherit
     with:

--- a/.github/workflows/ci-main-pull-request.yml
+++ b/.github/workflows/ci-main-pull-request.yml
@@ -1317,7 +1317,7 @@ jobs:
       
   BlackDuck-Polaris-SAST:
     name: 'BlackDuck Polaris SAST scan'
-    if: ${{ inputs.perform-blackduck-polaris && (github.event_name == 'push' || github.event_name == 'pull_request') }} # TODO: revert to 'push' only after ruby-erlang testing is complete
+    if: ${{ inputs.perform-blackduck-polaris && github.event_name == 'push' }}
     uses: chef/common-github-actions/.github/workflows/polaris-sast.yml@main
     needs: checkout
     secrets: inherit
@@ -1585,7 +1585,7 @@ jobs:
     name: 'Generating SBOM'
     #    Create software bill-of-materials (SBOM) using SPDX format
     if: ${{ inputs.generate-sbom == true }}
-    uses: chef/common-github-actions/.github/workflows/sbom.yml@ruby-erlang-fix # TODO: revert to @main after ruby-erlang-fix is merged
+    uses: chef/common-github-actions/.github/workflows/sbom.yml@main
     needs: checkout # TODO: fix set-application-version
     secrets: inherit
     with:
@@ -1593,7 +1593,7 @@ jobs:
       github-branch-name: ${{ inputs.github-branch-name }}
       version: ${{ inputs.version }}
       export-github-sbom: ${{ inputs.export-github-sbom }}
-      perform-blackduck-sca-scan: ${{ inputs.perform-blackduck-sca-scan && (github.event_name == 'push' || github.event_name == 'pull_request') }} # TODO: revert to 'push' only after ruby-erlang testing is complete
+      perform-blackduck-sca-scan: ${{ inputs.perform-blackduck-sca-scan && github.event_name == 'push' }}
       # generate-blackduck-sbom: ${{ inputs.generate-blackduck-sbom }}  # obsolete, remove TODO
       blackduck-project-group-name: ${{ inputs.blackduck-project-group-name }}
       blackduck-project-name: ${{ inputs.blackduck-project-name }}

--- a/.github/workflows/ci-main-pull-request.yml
+++ b/.github/workflows/ci-main-pull-request.yml
@@ -1317,7 +1317,7 @@ jobs:
       
   BlackDuck-Polaris-SAST:
     name: 'BlackDuck Polaris SAST scan'
-    if: ${{ inputs.perform-blackduck-polaris && github.event_name == 'push' }}
+    if: ${{ inputs.perform-blackduck-polaris && (github.event_name == 'push' || github.event_name == 'pull_request') }} # TODO: revert to 'push' only after ruby-erlang testing is complete
     uses: chef/common-github-actions/.github/workflows/polaris-sast.yml@main
     needs: checkout
     secrets: inherit

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -83,7 +83,7 @@ on:
         type: boolean
         default: false
       language:
-        description: 'Primary programming language of the project, used for SBOM enrichment (e.g., "ruby", "go", "python")'
+        description: 'Primary programming language of the project, used for SBOM enrichment (e.g., "ruby", "go", "python", "erlang", "ruby-erlang")'
         required: false
         type: string
         default: 'ruby'
@@ -234,7 +234,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Ruby and run bundle install
-        if: inputs.language == 'ruby'
+        if: inputs.language == 'ruby' || inputs.language == 'ruby-erlang'
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.4.2'
@@ -242,7 +242,7 @@ jobs:
           working-directory: ${{ inputs.ruby-app-directory != '' && inputs.ruby-app-directory || '.' }}
 
       - name: Configure Bundler for private Ruby gems
-        if: ${{ inputs.run-bundle-install == true && inputs.language == 'ruby' }}
+        if: ${{ inputs.run-bundle-install == true && (inputs.language == 'ruby' || inputs.language == 'ruby-erlang') }}
         run: |
           if [ -z "${{ secrets.PRIVATE_ACCESS_KITCHEN_CHEF_ENTERPRISE }}" ]; then
             echo "Skipping: PRIVATE_ACCESS_KITCHEN_CHEF_ENTERPRISE secret not configured or not in scope"
@@ -251,11 +251,19 @@ jobs:
           bundle config set --local github.com "x-access-token:${{ secrets.PRIVATE_ACCESS_KITCHEN_CHEF_ENTERPRISE }}"
 
       - name: Set up Erlang/OTP and rebar3
-        if: inputs.language == 'erlang'
+        if: inputs.language == 'erlang' || inputs.language == 'ruby-erlang'
         uses: erlef/setup-beam@v1
         with:
           otp-version: '25.3.2.16'
           rebar3-version: '3.22.0'
+
+      - name: Verify rebar3 installation and add to PATH
+        if: inputs.language == 'erlang' || inputs.language == 'ruby-erlang'
+        run: |
+          echo "Checking for rebar3..."
+          which rebar3 || echo "rebar3 not found in PATH"
+          rebar3 version || echo "rebar3 command failed"
+          echo "PATH: $PATH"
 
       - name: Configure git for private Go modules
         if : ${{ inputs.go-private-modules != '' }}
@@ -264,7 +272,7 @@ jobs:
         run: git config --global url."https://${{ secrets.GH_TOKEN }}@github.com/".insteadOf "https://github.com/"
 
       - name: generate Gemfile.lock if needed for Ruby projects
-        if: ${{ inputs.run-bundle-install == true && inputs.language == 'ruby' }} 
+        if: ${{ inputs.run-bundle-install == true && (inputs.language == 'ruby' || inputs.language == 'ruby-erlang') }} 
         continue-on-error: true
         working-directory: ${{ inputs.ruby-app-directory != '' && inputs.ruby-app-directory || '.' }}
         run: |
@@ -273,7 +281,7 @@ jobs:
           fi
 
       - name: attach artifact for Gemfile.lock for debugging
-        if: ${{ inputs.language == 'ruby' }} 
+        if: ${{ inputs.language == 'ruby' || inputs.language == 'ruby-erlang' }} 
         uses: actions/upload-artifact@v4
         continue-on-error: true
         with:

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -302,7 +302,7 @@ jobs:
           # Run `rebar3 get-deps` in every directory containing a rebar.config to generate
           # the lock files that the HEX detector relies on.
           # Also calculate the maximum nesting depth of rebar.config files so the detector
-          # search depth can be set dynamically — works for any repo layout, not just chef-server.
+          # search depth can be set dynamically — works for any repo layout.
           echo "Resolving Erlang/HEX dependencies via rebar3..."
           MAX_DEPTH=0
           while IFS= read -r cfg; do

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -301,12 +301,22 @@ jobs:
           # BlackDuck Detect needs rebar.lock files to accurately detect HEX dependencies.
           # Run `rebar3 get-deps` in every directory containing a rebar.config to generate
           # the lock files that the HEX detector relies on.
+          # Also calculate the maximum nesting depth of rebar.config files so the detector
+          # search depth can be set dynamically — works for any repo layout, not just chef-server.
           echo "Resolving Erlang/HEX dependencies via rebar3..."
-          find . -name "rebar.config" -not -path "*/.bridge/*" -not -path "*/node_modules/*" | while read cfg; do
+          MAX_DEPTH=0
+          while IFS= read -r cfg; do
             dir=$(dirname "$cfg")
             echo "Running rebar3 get-deps in: $dir"
             (cd "$dir" && rebar3 get-deps) || echo "rebar3 get-deps failed in $dir (continuing)"
-          done
+            # Count directory depth relative to repo root (number of '/' separators after leading ./)
+            depth=$(echo "$dir" | tr -cd '/' | wc -c)
+            [ "$depth" -gt "$MAX_DEPTH" ] && MAX_DEPTH="$depth"
+          done < <(find . -name "rebar.config" -not -path "*/.bridge/*" -not -path "*/node_modules/*" -not -path "*/.git/*")
+          # Ensure at least depth 1 so the root rebar.config is always found
+          [ "$MAX_DEPTH" -lt 1 ] && MAX_DEPTH=1
+          echo "ERLANG_DETECTOR_DEPTH=${MAX_DEPTH}" >> "$GITHUB_ENV"
+          echo "Erlang detector search depth: ${MAX_DEPTH}"
           echo "Erlang dependency resolution complete"
 
       - name: Resolve Ruby dependencies for BlackDuck scanning
@@ -314,23 +324,28 @@ jobs:
         continue-on-error: true
         run: |
           # BlackDuck Detect needs Gemfile.lock files to accurately detect RubyGems dependencies.
-          # Repos like chef-server have multiple Gemfiles across subdirectories at varying depths.
-          # Find every Gemfile that lacks a corresponding Gemfile.lock and run bundle install in
-          # that directory so Detect's Bundler detector can pick up all Ruby dependency trees.
+          # Find every Gemfile across the repo (at any depth), run bundle install where a
+          # Gemfile.lock is missing, and calculate the max nesting depth so the detector
+          # search depth covers all Gemfile locations — works for any repo layout.
           BASE_DIR="${{ inputs.ruby-app-directory != '' && inputs.ruby-app-directory || '.' }}"
           echo "Scanning for Gemfiles under: $BASE_DIR"
-          find "$BASE_DIR" -name "Gemfile" -not -name "*.lock" \
-            -not -path "*/.bridge/*" -not -path "*/node_modules/*" -not -path "*/.git/*" \
-            | while read gemfile; do
-              dir=$(dirname "$gemfile")
-              if [ ! -f "$dir/Gemfile.lock" ]; then
-                echo "No Gemfile.lock in $dir — running bundle install..."
-                (cd "$dir" && bundle install --without development test) \
-                  || echo "bundle install failed in $dir (continuing)"
-              else
-                echo "Gemfile.lock already exists in $dir — skipping"
-              fi
-            done
+          MAX_DEPTH=0
+          while IFS= read -r gemfile; do
+            dir=$(dirname "$gemfile")
+            depth=$(echo "$dir" | tr -cd '/' | wc -c)
+            [ "$depth" -gt "$MAX_DEPTH" ] && MAX_DEPTH="$depth"
+            if [ ! -f "$dir/Gemfile.lock" ]; then
+              echo "No Gemfile.lock in $dir — running bundle install..."
+              (cd "$dir" && bundle install --without development test) \
+                || echo "bundle install failed in $dir (continuing)"
+            else
+              echo "Gemfile.lock already exists in $dir — skipping"
+            fi
+          done < <(find "$BASE_DIR" -name "Gemfile" -not -name "*.lock" \
+            -not -path "*/.bridge/*" -not -path "*/node_modules/*" -not -path "*/.git/*")
+          [ "$MAX_DEPTH" -lt 1 ] && MAX_DEPTH=1
+          echo "RUBY_DETECTOR_DEPTH=${MAX_DEPTH}" >> "$GITHUB_ENV"
+          echo "Ruby detector search depth: ${MAX_DEPTH}"
           echo "Ruby dependency resolution complete"
 
       - name: Prepare Go workspace for BlackDuck scanning
@@ -390,12 +405,21 @@ jobs:
             DETECT_ARGS="${DETECT_ARGS} --detect.accuracy.required=NONE"
           fi
 
-          # For Erlang and ruby-erlang repos, rebar.config/rebar.lock files are often in
-          # subdirectories. Default detector search depth is 0 (root only), which means only
-          # the Git detector runs and HEX dependencies are never scanned.
-          # Increase depth to 5 to find rebar.config/rebar.lock in nested app directories.
+          # For Erlang, ruby-erlang, and pure Ruby repos, rebar.config/Gemfile files may
+          # be nested in subdirectories. Default detector search depth is 0 (root only),
+          # which causes only the Git detector to run. Use the dynamically calculated depth
+          # (max nesting of rebar.config or Gemfile in this repo) so this works for any layout.
           if [[ "${{ inputs.language }}" == "erlang" || "${{ inputs.language }}" == "ruby-erlang" ]]; then
-            DETECT_ARGS="${DETECT_ARGS} --detect.detector.search.depth=5"
+            ERLANG_DEPTH="${{ env.ERLANG_DETECTOR_DEPTH }}"
+            RUBY_DEPTH="${{ env.RUBY_DETECTOR_DEPTH }}"
+            # Use the greater of the two depths to cover both Ruby and Erlang file trees
+            MAX_DEPTH=$(( ERLANG_DEPTH > RUBY_DEPTH ? ERLANG_DEPTH : RUBY_DEPTH ))
+            [ "$MAX_DEPTH" -lt 1 ] && MAX_DEPTH=1
+            DETECT_ARGS="${DETECT_ARGS} --detect.detector.search.depth=${MAX_DEPTH}"
+          elif [[ "${{ inputs.language }}" == "ruby" ]]; then
+            RUBY_DEPTH="${{ env.RUBY_DETECTOR_DEPTH }}"
+            [ -n "$RUBY_DEPTH" ] && [ "$RUBY_DEPTH" -gt 0 ] && \
+              DETECT_ARGS="${DETECT_ARGS} --detect.detector.search.depth=${RUBY_DEPTH}"
           fi
           
           echo "DETECT_ARGS=${DETECT_ARGS}" >> $GITHUB_ENV

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -294,6 +294,45 @@ jobs:
         with:
           go-version: 'stable'
 
+      - name: Resolve Erlang/HEX dependencies for BlackDuck scanning
+        if: inputs.language == 'erlang' || inputs.language == 'ruby-erlang'
+        continue-on-error: true
+        run: |
+          # BlackDuck Detect needs rebar.lock files to accurately detect HEX dependencies.
+          # Run `rebar3 get-deps` in every directory containing a rebar.config to generate
+          # the lock files that the HEX detector relies on.
+          echo "Resolving Erlang/HEX dependencies via rebar3..."
+          find . -name "rebar.config" -not -path "*/.bridge/*" -not -path "*/node_modules/*" | while read cfg; do
+            dir=$(dirname "$cfg")
+            echo "Running rebar3 get-deps in: $dir"
+            (cd "$dir" && rebar3 get-deps) || echo "rebar3 get-deps failed in $dir (continuing)"
+          done
+          echo "Erlang dependency resolution complete"
+
+      - name: Resolve Ruby dependencies for BlackDuck scanning
+        if: ${{ inputs.run-bundle-install != true && (inputs.language == 'ruby' || inputs.language == 'ruby-erlang') }}
+        continue-on-error: true
+        run: |
+          # BlackDuck Detect needs Gemfile.lock files to accurately detect RubyGems dependencies.
+          # Repos like chef-server have multiple Gemfiles across subdirectories at varying depths.
+          # Find every Gemfile that lacks a corresponding Gemfile.lock and run bundle install in
+          # that directory so Detect's Bundler detector can pick up all Ruby dependency trees.
+          BASE_DIR="${{ inputs.ruby-app-directory != '' && inputs.ruby-app-directory || '.' }}"
+          echo "Scanning for Gemfiles under: $BASE_DIR"
+          find "$BASE_DIR" -name "Gemfile" -not -name "*.lock" \
+            -not -path "*/.bridge/*" -not -path "*/node_modules/*" -not -path "*/.git/*" \
+            | while read gemfile; do
+              dir=$(dirname "$gemfile")
+              if [ ! -f "$dir/Gemfile.lock" ]; then
+                echo "No Gemfile.lock in $dir — running bundle install..."
+                (cd "$dir" && bundle install --without development test) \
+                  || echo "bundle install failed in $dir (continuing)"
+              else
+                echo "Gemfile.lock already exists in $dir — skipping"
+              fi
+            done
+          echo "Ruby dependency resolution complete"
+
       - name: Prepare Go workspace for BlackDuck scanning
         if: ${{ hashFiles('go.work') != '' }}
         run: |
@@ -349,6 +388,14 @@ jobs:
           if [[ -f "go.work" ]]; then
             DETECT_ARGS="${DETECT_ARGS} --detect.detector.search.depth=${{ env.GO_WORK_DETECTOR_DEPTH }}"
             DETECT_ARGS="${DETECT_ARGS} --detect.accuracy.required=NONE"
+          fi
+
+          # For Erlang and ruby-erlang repos, rebar.config/rebar.lock files are often in
+          # subdirectories. Default detector search depth is 0 (root only), which means only
+          # the Git detector runs and HEX dependencies are never scanned.
+          # Increase depth to 5 to find rebar.config/rebar.lock in nested app directories.
+          if [[ "${{ inputs.language }}" == "erlang" || "${{ inputs.language }}" == "ruby-erlang" ]]; then
+            DETECT_ARGS="${DETECT_ARGS} --detect.detector.search.depth=5"
           fi
           
           echo "DETECT_ARGS=${DETECT_ARGS}" >> $GITHUB_ENV


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

<h2>Description</h2>
<p>
This PR implements and validates generic BlackDuck SCA and Polaris SAST scan logic for repositories containing Ruby, Erlang, or both. Key changes:
<ul>
  <li>Makes scan logic generic (no longer chef-server specific).</li>
  <li>Introduces dynamic search depth for BlackDuck to support nested Gemfile/rebar.config.</li>
  <li>Adds robust dependency resolution for Ruby (Bundler) and Erlang (rebar3/HEX).</li>
  <li>Ensures correct scan coverage for pure Ruby, pure Erlang, and mixed-language repos.</li>
  <li>Reverts all test-only changes (e.g., pull_request triggers, branch pinning, temporary gating) to restore production workflow gating.</li>
</ul>
Validation was performed on chef-server, a Ruby-only repo, and an Erlang-only repo. All scan results are as expected, with no regressions.
</p>

<h2>Related Issue</h2>
<p>
<!--- Please link to the issue, discourse, or stackoverflow here: -->
Addresses issues with SCA scan skipping for Ruby-Erlang repos and ensures generic, robust scan logic for all supported languages.
</p>

<h2>Types of changes</h2>
<ul>
  <li>[x] Bug fix (non-breaking change which fixes an issue)</li>
  <li>[x] Chore (non-breaking change that does not add functionality or fix an issue)</li>
  <li>[ ] New feature (non-breaking change which adds functionality)</li>
  <li>[ ] Breaking change (fix or feature that would cause existing functionality to change)</li>
</ul>

<h2>Checklist:</h2>
<ul>
  <li>[x] I have read the <strong>CONTRIBUTING</strong> document.</li>
  <li>[x] I have run the pre-merge tests locally and they pass.</li>
  <li>[x] I have updated the documentation accordingly.</li>
  <li>[x] I have added tests to cover my changes.</li>
  <li>[ ] If <code>Gemfile.lock</code> has changed, I have used <code>--conservative</code> to do it and included the full output in the Description above.</li>
  <li>[x] All new and existing tests passed.</li>
  <li>[x] All commits have been signed-off for <a href="https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco">the Developer Certificate of Origin</a>.</li>
</ul>