### PR TITLE
CHEF-33431: delegate platform-ui docker build to build-docker.sh

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -59,6 +59,9 @@ jobs:
         id: build-image
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          # WARNING: This workflow accesses a non-default secret. Ensure this secret is
+          # required and that it is stored securely in the repository or organization settings.
+          NPM_AZURE_KEY: ${{ secrets.NPM_AZURE_KEY }}
         run: |
           if [ ! -f "Dockerfile" ]; then
             echo "❌ No Dockerfile found - cannot build"
@@ -68,8 +71,25 @@ jobs:
           echo "Building Docker image..."
           REPO_NAME=$(basename $(pwd))
 
+          # Strategy 0: platform-ui - build with NPM Azure Key via buildx secret
+          if [ "${{ github.event.repository.name }}" = "platform-ui" ]; then
+            echo "Detected platform-ui - building with NPM Azure Key secret"
+            trap 'rm -f .npmrc.tmp' EXIT
+            printf '%s' "$NPM_AZURE_KEY" > .npmrc.tmp
+            docker buildx create --use
+            docker buildx build \
+              --secret id=npmrc,src=.npmrc.tmp \
+              --load \
+              --platform linux/amd64 \
+              --build-arg GITHUB_TOKEN="$GITHUB_TOKEN" \
+              --build-arg GIT_SHA="${{ github.sha }}" \
+              --build-arg APP_VERSION="${{ github.ref_name }}" \
+              --build-arg DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+              -t "${REPO_NAME}:latest" .
+            IMAGES="${REPO_NAME}:latest"
+
           # Strategy 1: Check for build-docker.sh script (e.g., dsm-erchef)
-          if [ -f "build-docker.sh" ]; then
+          elif [ -f "build-docker.sh" ]; then
             echo "Found build-docker.sh script - using it to build images"
             chmod +x build-docker.sh
             GITHUB_TOKEN="${{ secrets.GH_TOKEN }}" ./build-docker.sh

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -78,10 +78,9 @@ jobs:
             BRANCH_NAME="${{ github.head_ref || github.ref_name }}" \
             GIT_SHA="${{ github.sha }}" \
             APP_VERSION="${{ github.ref_name }}" \
-            RUN_ID="${{ github.run_id }}" \
             LOCALES="en" \
             ./build-docker.sh
-            IMAGES="platform-ui:${{ github.run_id }}"
+            IMAGES="platform-ui:local"
 
           # Strategy 1: Check for build-docker.sh script (e.g., dsm-erchef)
           elif [ -f "build-docker.sh" ]; then

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -80,7 +80,7 @@ jobs:
             APP_VERSION="${{ github.ref_name }}" \
             LOCALES="en" \
             ./build-docker.sh
-            IMAGES="platform-ui:local"
+            IMAGES=$(docker images --format "{{.Repository}}:{{.Tag}}" | grep -E "^${REPO_NAME}" | grep -v "^<none>")
 
           # Strategy 1: Check for build-docker.sh script (e.g., dsm-erchef)
           elif [ -f "build-docker.sh" ]; then

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -59,9 +59,6 @@ jobs:
         id: build-image
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-          # WARNING: This workflow accesses a non-default secret. Ensure this secret is
-          # required and that it is stored securely in the repository or organization settings.
-          NPM_AZURE_KEY: ${{ secrets.NPM_AZURE_KEY }}
         run: |
           if [ ! -f "Dockerfile" ]; then
             echo "❌ No Dockerfile found - cannot build"
@@ -71,22 +68,19 @@ jobs:
           echo "Building Docker image..."
           REPO_NAME=$(basename $(pwd))
 
-          # Strategy 0: platform-ui - build with NPM Azure Key via buildx secret
+          # Strategy 0: platform-ui — delegate entirely to build-docker.sh which handles
+          # submodule checkout (PAT), NPM Azure Key secret, and docker buildx build.
           if [ "${{ github.event.repository.name }}" = "platform-ui" ]; then
-            echo "Detected platform-ui - building with NPM Azure Key secret"
-            trap 'rm -f .npmrc.tmp' EXIT
-            printf '%s' "$NPM_AZURE_KEY" > .npmrc.tmp
-            docker buildx create --use
-            docker buildx build \
-              --secret id=npmrc,src=.npmrc.tmp \
-              --load \
-              --platform linux/amd64 \
-              --build-arg GITHUB_TOKEN="$GITHUB_TOKEN" \
-              --build-arg GIT_SHA="${{ github.sha }}" \
-              --build-arg APP_VERSION="${{ github.ref_name }}" \
-              --build-arg DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-              -t "${REPO_NAME}:latest" .
-            IMAGES="${REPO_NAME}:latest"
+            echo "Detected platform-ui - delegating to build-docker.sh"
+            chmod +x build-docker.sh
+            GITHUB_TOKEN="${{ secrets.GH_TOKEN }}" \
+            NPM_AZURE_KEY="${{ secrets.NPM_AZURE_KEY }}" \
+            BRANCH_NAME="${{ github.head_ref || github.ref_name }}" \
+            GIT_SHA="${{ github.sha }}" \
+            APP_VERSION="${{ github.ref_name }}" \
+            LOCALES="en" \
+            ./build-docker.sh
+            IMAGES="platform-ui:local"
 
           # Strategy 1: Check for build-docker.sh script (e.g., dsm-erchef)
           elif [ -f "build-docker.sh" ]; then

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -78,9 +78,10 @@ jobs:
             BRANCH_NAME="${{ github.head_ref || github.ref_name }}" \
             GIT_SHA="${{ github.sha }}" \
             APP_VERSION="${{ github.ref_name }}" \
+            RUN_ID="${{ github.run_id }}" \
             LOCALES="en" \
             ./build-docker.sh
-            IMAGES="platform-ui:local"
+            IMAGES="platform-ui:${{ github.run_id }}"
 
           # Strategy 1: Check for build-docker.sh script (e.g., dsm-erchef)
           elif [ -f "build-docker.sh" ]; then

--- a/.github/workflows/ci-main-pull-request.yml
+++ b/.github/workflows/ci-main-pull-request.yml
@@ -1016,7 +1016,7 @@ jobs:
   run-grype-image:
     name: 'Grype Docker image scan'
     if: ${{ inputs.perform-grype-image-scan }}
-    uses: chef/common-github-actions/.github/workflows/grype.yml@main
+    uses: chef/common-github-actions/.github/workflows/grype.yml@vaibhav/CHEF-33431-platform-ui-docker-build-fix
     needs: [checkout, build-docker-image]
     secrets: inherit
     with:

--- a/.github/workflows/ci-main-pull-request.yml
+++ b/.github/workflows/ci-main-pull-request.yml
@@ -1029,7 +1029,7 @@ jobs:
   build-docker-image:
     name: 'Build Docker image for security scans'
     if: ${{ inputs.perform-grype-image-scan == true || inputs.perform-wiz-scan == true }}
-    uses: chef/common-github-actions/.github/workflows/build-docker-image.yml@main
+    uses: chef/common-github-actions/.github/workflows/build-docker-image.yml@vaibhav/CHEF-33431-platform-ui-docker-build-fix
     needs: checkout
     secrets: inherit
     with:

--- a/.github/workflows/ci-main-pull-request.yml
+++ b/.github/workflows/ci-main-pull-request.yml
@@ -1016,7 +1016,7 @@ jobs:
   run-grype-image:
     name: 'Grype Docker image scan'
     if: ${{ inputs.perform-grype-image-scan }}
-    uses: chef/common-github-actions/.github/workflows/grype.yml@main
+    uses: chef/common-github-actions/.github/workflows/grype.yml@vaibhav/CHEF-33431-platform-ui-docker-build-fix
     needs: [checkout, build-docker-image]
     secrets: inherit
     with:
@@ -1029,7 +1029,7 @@ jobs:
   build-docker-image:
     name: 'Build Docker image for security scans'
     if: ${{ inputs.perform-grype-image-scan == true || inputs.perform-wiz-scan == true }}
-    uses: chef/common-github-actions/.github/workflows/build-docker-image.yml@main
+    uses: chef/common-github-actions/.github/workflows/build-docker-image.yml@vaibhav/CHEF-33431-platform-ui-docker-build-fix
     needs: checkout
     secrets: inherit
     with:

--- a/.github/workflows/ci-main-pull-request.yml
+++ b/.github/workflows/ci-main-pull-request.yml
@@ -1016,7 +1016,7 @@ jobs:
   run-grype-image:
     name: 'Grype Docker image scan'
     if: ${{ inputs.perform-grype-image-scan }}
-    uses: chef/common-github-actions/.github/workflows/grype.yml@vaibhav/CHEF-33431-platform-ui-docker-build-fix
+    uses: chef/common-github-actions/.github/workflows/grype.yml@main
     needs: [checkout, build-docker-image]
     secrets: inherit
     with:
@@ -1029,7 +1029,7 @@ jobs:
   build-docker-image:
     name: 'Build Docker image for security scans'
     if: ${{ inputs.perform-grype-image-scan == true || inputs.perform-wiz-scan == true }}
-    uses: chef/common-github-actions/.github/workflows/build-docker-image.yml@vaibhav/CHEF-33431-platform-ui-docker-build-fix
+    uses: chef/common-github-actions/.github/workflows/build-docker-image.yml@main
     needs: checkout
     secrets: inherit
     with:

--- a/.github/workflows/grype.yml
+++ b/.github/workflows/grype.yml
@@ -97,6 +97,9 @@ jobs:
         if: ${{ inputs.prebuilt-image-artifact == '' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          # WARNING: This workflow accesses a non-default secret. Ensure this secret is
+          # required and that it is stored securely in the repository or organization settings.
+          NPM_AZURE_KEY: ${{ secrets.NPM_AZURE_KEY }}
         run: |
           if [ ! -f "Dockerfile" ]; then
             echo "❌ No Dockerfile found - this workflow requires a Dockerfile to scan Docker image"
@@ -106,8 +109,25 @@ jobs:
           echo "Building Docker image..."
           REPO_NAME=$(basename $(pwd))
           
+          # Strategy 0: platform-ui - build with NPM Azure Key via buildx secret
+          if [ "${{ github.event.repository.name }}" = "platform-ui" ]; then
+            echo "Detected platform-ui - building with NPM Azure Key secret"
+            trap 'rm -f .npmrc.tmp' EXIT
+            printf '%s' "$NPM_AZURE_KEY" > .npmrc.tmp
+            docker buildx create --use
+            docker buildx build \
+              --secret id=npmrc,src=.npmrc.tmp \
+              --load \
+              --platform linux/amd64 \
+              --build-arg GITHUB_TOKEN="$GITHUB_TOKEN" \
+              --build-arg GIT_SHA="${{ github.sha }}" \
+              --build-arg APP_VERSION="${{ github.ref_name }}" \
+              --build-arg DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+              -t "${REPO_NAME}:latest" .
+            IMAGES="${REPO_NAME}:latest"
+
           # Strategy 1: Check for build-docker.sh script (e.g., dsm-erchef)
-          if [ -f "build-docker.sh" ]; then
+          elif [ -f "build-docker.sh" ]; then
             echo "Found build-docker.sh script - using it to build images"
             chmod +x build-docker.sh
             GITHUB_TOKEN="${{ secrets.GH_TOKEN }}" ./build-docker.sh

--- a/.github/workflows/grype.yml
+++ b/.github/workflows/grype.yml
@@ -97,9 +97,6 @@ jobs:
         if: ${{ inputs.prebuilt-image-artifact == '' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-          # WARNING: This workflow accesses a non-default secret. Ensure this secret is
-          # required and that it is stored securely in the repository or organization settings.
-          NPM_AZURE_KEY: ${{ secrets.NPM_AZURE_KEY }}
         run: |
           if [ ! -f "Dockerfile" ]; then
             echo "❌ No Dockerfile found - this workflow requires a Dockerfile to scan Docker image"
@@ -109,22 +106,19 @@ jobs:
           echo "Building Docker image..."
           REPO_NAME=$(basename $(pwd))
           
-          # Strategy 0: platform-ui - build with NPM Azure Key via buildx secret
+          # Strategy 0: platform-ui — delegate entirely to build-docker.sh which handles
+          # submodule checkout (PAT), NPM Azure Key secret, and docker buildx build.
           if [ "${{ github.event.repository.name }}" = "platform-ui" ]; then
-            echo "Detected platform-ui - building with NPM Azure Key secret"
-            trap 'rm -f .npmrc.tmp' EXIT
-            printf '%s' "$NPM_AZURE_KEY" > .npmrc.tmp
-            docker buildx create --use
-            docker buildx build \
-              --secret id=npmrc,src=.npmrc.tmp \
-              --load \
-              --platform linux/amd64 \
-              --build-arg GITHUB_TOKEN="$GITHUB_TOKEN" \
-              --build-arg GIT_SHA="${{ github.sha }}" \
-              --build-arg APP_VERSION="${{ github.ref_name }}" \
-              --build-arg DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-              -t "${REPO_NAME}:latest" .
-            IMAGES="${REPO_NAME}:latest"
+            echo "Detected platform-ui - delegating to build-docker.sh"
+            chmod +x build-docker.sh
+            GITHUB_TOKEN="${{ secrets.GH_TOKEN }}" \
+            NPM_AZURE_KEY="${{ secrets.NPM_AZURE_KEY }}" \
+            BRANCH_NAME="${{ github.head_ref || github.ref_name }}" \
+            GIT_SHA="${{ github.sha }}" \
+            APP_VERSION="${{ github.ref_name }}" \
+            LOCALES="en" \
+            ./build-docker.sh
+            IMAGES="platform-ui:local"
 
           # Strategy 1: Check for build-docker.sh script (e.g., dsm-erchef)
           elif [ -f "build-docker.sh" ]; then

--- a/.github/workflows/grype.yml
+++ b/.github/workflows/grype.yml
@@ -118,7 +118,7 @@ jobs:
             APP_VERSION="${{ github.ref_name }}" \
             LOCALES="en" \
             ./build-docker.sh
-            IMAGES="platform-ui:local"
+            IMAGES=$(docker images --format "{{.Repository}}:{{.Tag}}" | grep -E "^${REPO_NAME}" | grep -v "^<none>")
 
           # Strategy 1: Check for build-docker.sh script (e.g., dsm-erchef)
           elif [ -f "build-docker.sh" ]; then

--- a/.github/workflows/wiz.yml
+++ b/.github/workflows/wiz.yml
@@ -107,8 +107,22 @@ jobs:
           echo "Building Docker image..."
           REPO_NAME=$(basename $(pwd))
 
+          # Strategy 0: platform-ui — delegate entirely to build-docker.sh which handles
+          # submodule checkout (GITHUB_TOKEN), NPM Azure Key secret, and docker buildx build.
+          if [ "${{ github.event.repository.name }}" = "platform-ui" ]; then
+            echo "Detected platform-ui - delegating to build-docker.sh"
+            chmod +x build-docker.sh
+            GITHUB_TOKEN="${{ secrets.GH_TOKEN }}" \
+            NPM_AZURE_KEY="${{ secrets.NPM_AZURE_KEY }}" \
+            BRANCH_NAME="${{ github.head_ref || github.ref_name }}" \
+            GIT_SHA="${{ github.sha }}" \
+            APP_VERSION="${{ github.ref_name }}" \
+            LOCALES="en" \
+            ./build-docker.sh
+            IMAGES="platform-ui:local"
+
           # Strategy 1: Check for build-docker.sh script (e.g., dsm-erchef)
-          if [ -f "build-docker.sh" ]; then
+          elif [ -f "build-docker.sh" ]; then
             echo "Found build-docker.sh script - using it to build images"
             chmod +x build-docker.sh
             GITHUB_TOKEN="${{ secrets.GH_TOKEN }}" ./build-docker.sh

--- a/.github/workflows/wiz.yml
+++ b/.github/workflows/wiz.yml
@@ -119,7 +119,7 @@ jobs:
             APP_VERSION="${{ github.ref_name }}" \
             LOCALES="en" \
             ./build-docker.sh
-            IMAGES="platform-ui:local"
+            IMAGES=$(docker images --format "{{.Repository}}:{{.Tag}}" | grep -E "^${REPO_NAME}" | grep -v "^<none>")
 
           # Strategy 1: Check for build-docker.sh script (e.g., dsm-erchef)
           elif [ -f "build-docker.sh" ]; then


### PR DESCRIPTION
## Summary

Fixes the Grype Docker image scan for `platform-ui` in the common CI workflow.

### Problem
The common workflow's `grype.yml` and `build-docker-image.yml` ran `docker build` without the BuildKit secret required by the `platform-ui` Dockerfile (`NPM_AZURE_KEY` for Azure Artifacts npm packages), causing the build to fail.

### Solution
Replace the inline Strategy 0 docker build block in both workflow files with a simple call to the repo's own `build-docker.sh` script (updated in [platform-ui PR #1424](https://github.com/progress-platform-services/platform-ui/pull/1424)).

The script is now fully self-contained and handles:
- Submodule checkout using `GITHUB_TOKEN` (with per-submodule branch fallback to `main`)
- `NPM_AZURE_KEY` written to `.npmrc.tmp` as a BuildKit secret mount
- `docker buildx build --load`, image tagged `platform-ui:local` for Grype scan detection

### Changes
- `grype.yml`: Strategy 0 block replaced with `./build-docker.sh` call + env vars
- `build-docker-image.yml`: Same replacement
- `NPM_AZURE_KEY` removed from step-level `env:` block (passed inline to script only)

### Env vars passed to script
| Var | Source |
|-----|--------|
| `GITHUB_TOKEN` | `secrets.GH_TOKEN` — git submodule auth + docker build arg |
| `NPM_AZURE_KEY` | `secrets.NPM_AZURE_KEY` — Azure Artifacts npm token |
| `BRANCH_NAME` | `github.head_ref \|\| github.ref_name` |
| `GIT_SHA` | `github.sha` |
| `APP_VERSION` | `github.ref_name` |
| `LOCALES` | `"en"` |

### Testing
platform-ui `ci-main-pull-request-checks.yml` already points at this feature branch via PR #1424.